### PR TITLE
Simplify lgtm.yml for LGTM.com C/C++ analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,34 +2,9 @@ path_classifiers:
     test:
         - src/test
         - include/test
-    drivers:
-        - src/dev
-        - include/dev
-    gc:
-        - src/gc
-        - include/gc
-    acpi:
-        - src/acpi
-        - include/acpi
-    net:
-        - src/net
-        - include/net
-    rt:
-        - src/rt
-        - include/rt
-    core:
-        - src/nautilus
-        - include/nautilus
 
 extraction:
     cpp:
-        prepare:
-            packages:
-                - gcc
-                - libstdc++-static
-            configure:
-                command: 
-                    - $GNU_MAKE defconfig
-            index:
-                build_command:
-                    - $GNU_MAKE -j6
+        configure:
+            command: 
+                - make defconfig


### PR DESCRIPTION
Hi team,

I noticed that you tried to configure LGTM.com analysis for your C/C++, but unfortunately there's a small error in your `.lgtm.yml` configuration file. This PR fixes the configuration. I've actually simplified it slightly.:

- The most important bit: `configure` shouldn't be under `prepare`, but directly under `cpp`. More details here: https://lgtm.com/help/lgtm/cpp-extraction
- I've further simplified the configuration by removing the `index` and `build_command`: LGTM will figure these out automatically.
- I've also removed the explicit installation of Debian packages: LGTM will do that automatically (more details on how that works [here](https://lgtm.com/blog/how_lgtm_builds_cplusplus))
- I've removed all `path_classifiers` entries, apart from `test`: the path classifiers are to instruct LGTM to exclude results that are found in particular files (e.g. test code, generated code, library code). You probably didn't intend to exclude those results.

As soon as this PR is merged I'll trigger another C/C++ build, which should then also enable the automated code review for C/C++ in pull requests. Any questions: just ping me!

(Full disclosure: I'm part of the team that's responsible for LGTM.com)