### PR TITLE
Shell rewrite

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -775,6 +775,14 @@ menu Debugging
       help
         Turn on debug prints for SMP code
 
+    config DEBUG_SHELL
+      bool "Debug Shell"
+      depends on DEBUG_PRINTS
+      default n
+      help
+        Turn on debug prints for the shell
+
+
     config DEBUG_HRT
       bool "Debug HRT"
       depends on DEBUG_PRINTS && HVM_HRT

--- a/include/lua/lua.h
+++ b/include/lua/lua.h
@@ -9,10 +9,7 @@
 #ifndef lua_h
 #define lua_h
 
-//#include <stdarg.h>
-//#include <stddef.h>
 #include <nautilus/libccompat.h>
-
 #include "luaconf.h"
 
 
@@ -396,7 +393,6 @@ LUA_API int (lua_gethookmask) (lua_State *L);
 LUA_API int (lua_gethookcount) (lua_State *L);
 
 int lua_main(int argc, char **argv);
-void handle_lua_cmd(char *);
 struct lua_Debug {
   int event;
   const char *name;	/* (n) */

--- a/include/nautilus/pmc.h
+++ b/include/nautilus/pmc.h
@@ -236,8 +236,4 @@ void     nk_pmc_write(perf_event_t * event, uint64_t val);
 
 void     nk_pmc_report(void);
 
-
-void test_pmc(int pmc_id);
-
-
 #endif /* !__PMC_H__! */

--- a/include/nautilus/prog.h
+++ b/include/nautilus/prog.h
@@ -34,8 +34,6 @@ struct nk_prog_info {
     char ** argv;
 };
 
-int handle_prog_cmd (char * buf);
-
 int nk_prog_init (struct naut_info * naut);
 int nk_prog_run (struct naut_info * naut);
 

--- a/include/nautilus/shell.h
+++ b/include/nautilus/shell.h
@@ -15,7 +15,8 @@
  *                     The Hobbes Project <http://xstack.sandia.gov/hobbes>
  * All rights reserved.
  *
- * Author: Peter Dinda <pdinda@northwestern.edu>
+ * Authors: Peter Dinda <pdinda@northwestern.edu>
+ *          Kyle Hale <khale@cs.iit.edu>
  *
  * This is free software.  You are permitted to use,
  * redistribute, and modify it as specified in the file "LICENSE.txt".
@@ -24,11 +25,30 @@
 #ifndef __NK_SHELL
 #define __NK_SHELL
 
-
-#include <nautilus/thread.h>
-
 #define NK_SHELL_SCRIPT_ONLY 0x1
+#define SHELL_OP_NAME_LEN 32
+#define SHELL_MAX_CMD 80
+#define SHELL_STACK_SIZE (PAGE_SIZE_2MB) 
+
+#define PROMPT_CHAR 0xcf
+#define INPUT_CHAR  0x3f
+#define OUTPUT_CHAR 0x9f
+
+#define RTREE_NUM_ENTRIES 26
+
+struct shell_cmd_impl {
+    char * cmd;
+    char * help_str;
+    int (*handler)(char * buf, void * priv);
+};
 
 nk_thread_id_t nk_launch_shell(char *name, int cpu, char **script, uint32_t flags);
+
+#define nk_register_shell_cmd(cmd) \
+    static struct shell_cmd_impl * _nk_cmd_##cmd \
+    __attribute__((used)) \
+    __attribute__((unused, __section__(".shell_cmds"), \
+        aligned(sizeof(void*)))) \
+    = &cmd;
 
 #endif

--- a/include/nautilus/shell.h
+++ b/include/nautilus/shell.h
@@ -37,8 +37,8 @@
 #define INPUT_CHAR  0x3f
 #define OUTPUT_CHAR 0x9f
 
-/* 'a'-'z' , '-', '_', ' '  */
-#define RTREE_NUM_ENTRIES 29
+/* '0'-'9', 'a'-'z' , '-', '_', ' '  */
+#define RTREE_NUM_ENTRIES 39
 
 struct shell_cmd_impl {
     char * cmd;

--- a/include/nautilus/shell.h
+++ b/include/nautilus/shell.h
@@ -30,11 +30,15 @@
 #define SHELL_MAX_CMD 80
 #define SHELL_STACK_SIZE (PAGE_SIZE_2MB) 
 
+#define SHELL_HIST_BUF_SZ 128
+#define SHELL_DEFAULT_HIST_DISPLAY 20
+
 #define PROMPT_CHAR 0xcf
 #define INPUT_CHAR  0x3f
 #define OUTPUT_CHAR 0x9f
 
-#define RTREE_NUM_ENTRIES 26
+/* 'a'-'z' , '-', '_', ' '  */
+#define RTREE_NUM_ENTRIES 29
 
 struct shell_cmd_impl {
     char * cmd;

--- a/include/nautilus/vc.h
+++ b/include/nautilus/vc.h
@@ -74,6 +74,7 @@ int nk_vc_clear_specific(struct nk_virtual_console *vc, uint8_t attr);
 int nk_vc_scrollup(void);
 int nk_vc_scrollup_specific(struct nk_virtual_console *vc);
 int nk_vc_setpos(uint8_t x, uint8_t y);
+void nk_vc_getpos(uint8_t * x, uint8_t * y);
 int nk_vc_setpos_specific(struct nk_virtual_console *vc, uint8_t x, uint8_t y);
 int nk_vc_display_char(uint8_t c, uint8_t attr, uint8_t x, uint8_t y);
 int nk_vc_display_char_specific(struct nk_virtual_console *vc,
@@ -89,7 +90,7 @@ nk_scancode_t nk_vc_get_scancode(int wait);
 
 int nk_vc_getchar_extended(int wait);
 int nk_vc_getchar();
-int nk_vc_gets(char *buf, int n, int display);
+int nk_vc_gets(char *buf, int n, int display, int(*notifier)(char * buf, void * priv, int o), void * priv);
 
 int nk_vc_handle_keyboard(nk_scancode_t scan);
 int nk_vc_handle_mouse(nk_mouse_event_t *mouse);

--- a/link/nautilus.ld
+++ b/link/nautilus.ld
@@ -78,6 +78,12 @@ SECTIONS
         *(.gnu.linkconce.got*)
     }
 
+    .shell_cmds ALIGN(0x1000) : AT(ADDR(.got)+SIZEOF(.got))
+    {
+        __start_shell_cmds = .;
+        *(.shell_cmds*);
+        __stop_shell_cmds = .;
+    }
 
     _loadEnd = .; 
     

--- a/scripts/kconfig/zconf.hash.c
+++ b/scripts/kconfig/zconf.hash.c
@@ -153,9 +153,6 @@ static struct kconf_id_strings_t kconf_id_strings_contents =
     "prompt"
   };
 #define kconf_id_strings ((const char *) &kconf_id_strings_contents)
-//#ifdef __GNUC__
-//__inline
-//#endif
 struct kconf_id *
 kconf_id_lookup (register const char *str, register unsigned int len)
 {

--- a/src/dev/Kconfig
+++ b/src/dev/Kconfig
@@ -65,7 +65,7 @@ config DEBUG_APIC
         Turn on debug prints for the LAPIC driver
 
 config DEBUG_IOAPIC
-    bool "DEBUG IOAPIC"
+    bool "Debug IOAPIC"
     depends on DEBUG_PRINTS
     default n
     help 

--- a/src/gc/Makefile
+++ b/src/gc/Makefile
@@ -1,2 +1,4 @@
 obj-$(NAUT_CONFIG_ENABLE_BDWGC) += bdwgc/
 obj-$(NAUT_CONFIG_ENABLE_PDSGC) += pdsgc/
+
+obj-$(NAUT_CONFIG_GARBAGE_COLLECTION) += gc.o

--- a/src/gc/gc.c
+++ b/src/gc/gc.c
@@ -1,0 +1,125 @@
+/* 
+ * This file is part of the Nautilus AeroKernel developed
+ * by the Hobbes and V3VEE Projects with funding from the 
+ * United States National  Science Foundation and the Department of Energy.  
+ *
+ * The V3VEE Project is a joint project between Northwestern University
+ * and the University of New Mexico.  The Hobbes Project is a collaboration
+ * led by Sandia National Laboratories that includes several national 
+ * laboratories and universities. You can find out more at:
+ * http://www.v3vee.org  and
+ * http://xstack.sandia.gov/hobbes
+ *
+ * Copyright (c) 2018, Kyle Hale <khale@cs.iit.edu>
+ * Copyright (c) 2016, The V3VEE Project  <http://www.v3vee.org> 
+ *                     The Hobbes Project <http://xstack.sandia.gov/hobbes>
+ * All rights reserved.
+ *
+ * Authors: Kyle Hale <khale@cs.iit.edu>
+ *         
+ * This is free software.  You are permitted to use,
+ * redistribute, and modify it as specified in the file "LICENSE.txt".
+ */
+#include <nautilus/nautilus.h>
+#include <nautilus/shell.h>
+
+#ifdef NAUT_CONFIG_ENABLE_BDWGC
+#include <gc/bdwgc/bdwgc.h>
+#endif
+
+#ifdef NAUT_CONFIG_ENABLE_PDSGC
+#include <gc/pdsgc/pdsgc.h>
+#endif
+
+static int 
+handle_collect (char * buf, void * priv)
+{
+#ifdef NAUT_CONFIG_ENABLE_BDWGC
+    nk_vc_printf("Doing BDWGC global garbage collection\n");
+    int rc = nk_gc_bdwgc_collect();
+    nk_vc_printf("BDWGC global garbage collection done result: %d\n",rc);
+    return 0;
+#else
+#ifdef NAUT_CONFIG_ENABLE_PDSGC
+    nk_vc_printf("Doing PDSGC global garbage collection\n");
+    struct nk_gc_pdsgc_stats s;
+    int rc = nk_gc_pdsgc_collect(&s);
+    nk_vc_printf("PDSGC global garbage collection done result: %d\n",rc);
+    nk_vc_printf("%lu blocks / %lu bytes freed\n",
+		 s.num_blocks, s.total_bytes);
+    nk_vc_printf("smallest freed block: %lu bytes, largest freed block: %lu bytes\n",
+		 s.min_block, s.max_block);
+    return 0;
+#else 
+    nk_vc_printf("No garbage collector is enabled...\n");
+    return 0;
+#endif
+#endif
+}
+
+
+static int 
+handle_leaks (char * buf, void * priv)
+{
+#ifdef NAUT_CONFIG_ENABLE_BDWGC
+    nk_vc_printf("Leak detection not available for BDWGC\n");
+    return 0;
+#else
+#ifdef NAUT_CONFIG_ENABLE_PDSGC
+    nk_vc_printf("Doing PDSGC global leak detection\n");
+    struct nk_gc_pdsgc_stats s;
+    int rc = nk_gc_pdsgc_leak_detect(&s);
+    nk_vc_printf("PDSGC global leak detection done result: %d\n",rc);
+    nk_vc_printf("%lu blocks / %lu bytes have leaked\n",
+		 s.num_blocks, s.total_bytes);
+    nk_vc_printf("smallest leaked block: %lu bytes, largest leaked block: %lu bytes\n",
+		 s.min_block, s.max_block);
+    return 0;
+#else 
+    nk_vc_printf("No garbage collector is enabled...\n");
+    return 0;
+#endif
+#endif
+}
+
+static int
+handle_bdwgc (char * buf, void * priv)
+{
+    nk_vc_printf("Testing BDWGC garbage collector\n");
+    return nk_gc_bdwgc_test();
+}
+
+static int
+handle_pdsgc (char * buf, void * priv)
+{
+	nk_vc_printf("Testing PDSGC garbage collector\n");
+	return nk_gc_pdsgc_test();
+}
+
+static struct shell_cmd_impl collect_impl = {
+    .cmd      = "collect",
+    .help_str = "collect",
+    .handler  = handle_collect,
+};
+nk_register_shell_cmd(collect_impl);
+
+static struct shell_cmd_impl leaks_impl = {
+    .cmd      = "leaks",
+    .help_str = "leaks",
+    .handler  = handle_leaks,
+};
+nk_register_shell_cmd(leaks_impl);
+
+static struct shell_cmd_impl bdwgc_impl = {
+    .cmd      = "bdwgc",
+    .help_str = "bdwgc",
+    .handler  = handle_bdwgc,
+};
+nk_register_shell_cmd(bdwgc_impl);
+
+static struct shell_cmd_impl pdsgc_impl = {
+    .cmd      = "pdsgc",
+    .help_str = "pdsgc",
+    .handler  = handle_pdsgc,
+};
+nk_register_shell_cmd(pdsgc_impl);

--- a/src/lua_src/lua.c
+++ b/src/lua_src/lua.c
@@ -607,8 +607,8 @@ lua_main (int argc, char ** argv)
 #define LUA_MAX_CMD_TOKENS 128
 #define LUA_MAX_TOKEN_LEN 64
 
-void 
-handle_lua_cmd (char * buf)
+static int 
+handle_lua_cmd (char * buf, void * priv)
 {
     char * argv[LUA_MAX_CMD_TOKENS];
     char * tmp  = NULL;
@@ -637,4 +637,13 @@ handle_lua_cmd (char * buf)
     for (i = 0; i < count; i++) {
         free(argv[i]);
     }
+
+    return 0;
 }
+
+static struct shell_cmd_impl lua_impl = {
+    .cmd      = "lua",
+    .help_str = "lua",
+    .handler  = handle_lua_cmd,
+};
+nk_register_shell_cmd(lua_impl);

--- a/src/nautilus/cpu.c
+++ b/src/nautilus/cpu.c
@@ -8,7 +8,7 @@
  * led by Sandia National Laboratories that includes several national 
  * laboratories and universities. You can find out more at:
  * http://www.v3vee.org  and
- * http://xtack.sandia.gov/hobbes
+ * http://xstack.sandia.gov/hobbes
  *
  * Copyright (c) 2015, Kyle C. Hale <kh@u.northwestern.edu>
  * Copyright (c) 2015, The V3VEE Project  <http://www.v3vee.org> 
@@ -26,6 +26,8 @@
 #include <nautilus/percpu.h>
 #include <nautilus/naut_types.h>
 #include <nautilus/naut_string.h>
+#include <nautilus/backtrace.h>
+#include <nautilus/shell.h>
 #include <nautilus/irq.h>
 #include <dev/i8254.h>
 
@@ -84,3 +86,121 @@ out_err:
     irq_enable_restore(flags);
     return -1;
 }
+
+
+static int
+handle_regs (char * buf, void * priv)
+{
+    extern int nk_interrupt_like_trampoline(void (*)(struct nk_regs *));
+    uint64_t tid;
+
+    if (sscanf(buf,"regs %lu",&tid) == 1) { 
+        nk_thread_t *t = nk_find_thread_by_tid(tid);
+        if (!t) {
+            nk_vc_printf("No such thread\n");
+        } else {
+            nk_print_regs((struct nk_regs *) t->rsp);
+        }
+        return 0;
+    }
+
+    nk_interrupt_like_trampoline(nk_print_regs);
+
+    return 0;
+}
+
+static struct shell_cmd_impl regs_impl = {
+    .cmd      = "regs",
+    .help_str = "regs [t]",
+    .handler  = handle_regs,
+};
+nk_register_shell_cmd(regs_impl);
+
+static int
+handle_in (char * buf, void * priv)
+{
+    uint64_t data, addr;
+    char bwdq;
+
+    if (((bwdq='b', sscanf(buf,"in b %lx", &addr))==1) ||
+            ((bwdq='w', sscanf(buf,"in w %lx", &addr))==1) ||
+            ((bwdq='d', sscanf(buf,"in d %lx", &addr))==1) ||
+            ((bwdq='b', sscanf(buf,"in %lx", &addr))==1)) {
+        addr &= 0xffff; // 16 bit address space
+        switch (bwdq) { 
+            case 'b': 
+                data = (uint64_t) inb(addr);
+                nk_vc_printf("IO[0x%04lx] = 0x%02lx\n",addr,data);
+                break;
+            case 'w': 
+                data = (uint64_t) inw(addr);
+                nk_vc_printf("IO[0x%04lx] = 0x%04lx\n",addr,data);
+                break;
+            case 'd': 
+                data = (uint64_t) inl(addr);
+                nk_vc_printf("IO[0x%04lx] = 0x%08lx\n",addr,data);
+                break;
+            default:
+                nk_vc_printf("Unknown size requested\n",bwdq);
+                break;
+        }
+        return 0;
+    }
+
+    nk_vc_printf("invalid in command\n");
+
+    return 0;
+}
+
+static struct shell_cmd_impl in_impl = {
+    .cmd      = "in",
+    .help_str = "in [bwd] addr",
+    .handler  = handle_in,
+};
+nk_register_shell_cmd(in_impl);
+
+static int
+handle_out (char * buf, void * priv)
+{
+    uint64_t data, addr;
+    char bwdq;
+
+    if (((bwdq='b', sscanf(buf,"out b %lx %lx", &addr,&data))==2) ||
+            ((bwdq='w', sscanf(buf,"out w %lx %lx", &addr,&data))==2) ||
+            ((bwdq='d', sscanf(buf,"out d %lx %lx", &addr,&data))==2) ||
+            ((bwdq='q', sscanf(buf,"out %lx %lx", &addr, &data))==2)) {
+        addr &= 0xffff;
+        switch (bwdq) { 
+            case 'b': 
+                data &= 0xff;
+                outb((uint8_t) data, (uint16_t)addr);
+                nk_vc_printf("IO[0x%04lx] = 0x%02lx\n",addr,data);
+                break;
+            case 'w': 
+                data &= 0xffff;
+                outw((uint16_t) data, (uint16_t)addr);
+                nk_vc_printf("IO[0x%04lx] = 0x%04lx\n",addr,data);
+                break;
+            case 'd': 
+                data &= 0xffffffff;
+                outl((uint32_t) data, (uint16_t)addr);
+                nk_vc_printf("IO[0x%04lx] = 0x%08lx\n",addr,data);
+                break;
+            default:
+                nk_vc_printf("Unknown size requested\n");
+                break;
+        }
+        return 0;
+    }
+
+    nk_vc_printf("invalid out command\n");
+
+    return 0;
+}
+
+static struct shell_cmd_impl out_impl = {
+    .cmd      = "out",
+    .help_str = "out [bwd] addr data",
+    .handler  = handle_out,
+};
+nk_register_shell_cmd(out_impl);

--- a/src/nautilus/dev.c
+++ b/src/nautilus/dev.c
@@ -25,6 +25,7 @@
 #include <nautilus/spinlock.h>
 #include <nautilus/dev.h>
 #include <nautilus/thread.h>
+#include <nautilus/shell.h>
 
 #ifndef NAUT_CONFIG_DEBUG_DEV
 #undef DEBUG_PRINT
@@ -176,3 +177,18 @@ void nk_dev_dump_devices()
     STATE_UNLOCK();
 }
 
+
+static int
+handle_devs (char * buf, void * priv)
+{
+    nk_dev_dump_devices();
+    return 0;
+}
+
+
+static struct shell_cmd_impl devs_impl = {
+    .cmd      = "devs",
+    .help_str = "devs",
+    .handler  = handle_devs,
+};
+nk_register_shell_cmd(devs_impl);

--- a/src/nautilus/gdb-stub.c
+++ b/src/nautilus/gdb-stub.c
@@ -188,6 +188,7 @@
 #include <nautilus/idt.h>
 #include <nautilus/shutdown.h>
 #include <nautilus/scheduler.h>
+#include <nautilus/shell.h>
 #include <nautilus/gdb-stub.h>
 #include <nautilus/cpu_state.h>
 
@@ -1467,3 +1468,17 @@ int nk_gdb_init_ap()
     return 0;
 }
 
+static int
+handle_break (char * buf, void * priv)
+{
+    nk_gdb_breakpoint_here();
+    return 0;
+}
+
+
+static struct shell_cmd_impl break_impl = {
+    .cmd      = "break",
+    .help_str = "break",
+    .handler  = handle_break,
+};
+nk_register_shell_cmd(break_impl);

--- a/src/nautilus/hashtable.c
+++ b/src/nautilus/hashtable.c
@@ -656,7 +656,7 @@ nk_htable_get_iter_key (struct nk_hashtable_iter * iter)
 
 addr_t 
 nk_htable_get_iter_value (struct nk_hashtable_iter * iter) 
-{ 
+{
     return iter->entry->value; 
 }
 

--- a/src/nautilus/loader.c
+++ b/src/nautilus/loader.c
@@ -25,6 +25,7 @@
 #include <nautilus/nautilus_exe.h>
 #include <nautilus/loader.h>
 #include <nautilus/fs.h>
+#include <nautilus/shell.h>
 
 #ifndef NAUT_CONFIG_DEBUG_LOADER
 #undef DEBUG_PRINT
@@ -537,3 +538,42 @@ nk_loader_deinit ()
     DEBUG("deinit\n");
 }
 
+
+static int
+handle_run (char * buf, void * priv)
+{
+    char path[80];
+
+    if (sscanf(buf,"run %s", path)!=1) { 
+        nk_vc_printf("Can't determine what to run\n");
+        return 0;
+    }
+
+    struct nk_exec *e = nk_load_exec(path);
+
+    if (!e) { 
+        nk_vc_printf("Can't load %s\n", path);
+        return 0;
+    }
+
+    nk_vc_printf("Loaded executable, now running\n");
+
+    if (nk_start_exec(e,0,0)) { 
+        nk_vc_printf("Failed to run %s\n", path);
+    }
+
+    nk_vc_printf("Unloading executable\n");
+
+    if (nk_unload_exec(e)) { 
+        nk_vc_printf("Failed to unload %s\n",path);
+    }
+
+    return 0;
+}    
+
+static struct shell_cmd_impl run_impl = {
+    .cmd      = "run",
+    .help_str = "run path",
+    .handler  = handle_run,
+};
+nk_register_shell_cmd(run_impl);

--- a/src/nautilus/msg_queue.c
+++ b/src/nautilus/msg_queue.c
@@ -26,6 +26,7 @@
 #include <nautilus/scheduler.h>
 #include <nautilus/msg_queue.h>
 #include <nautilus/list.h>
+#include <nautilus/shell.h>
 
 // This is a trival implementation of classic message queues for threads ONLY
 // interrupt handlers can use the "try" functions
@@ -455,3 +456,17 @@ int nk_msg_queue_pull_timeout(struct nk_msg_queue *q, void **m, uint64_t timeout
     return 1;
 }
 
+static int
+handle_mqs (char * buf, void * priv)
+{
+    nk_msg_queue_dump_queues();
+    return 0;
+}
+
+
+static struct shell_cmd_impl mqs_impl = {
+    .cmd      = "mqs",
+    .help_str = "mqs",
+    .handler  = handle_mqs,
+};
+nk_register_shell_cmd(mqs_impl);

--- a/src/nautilus/msr.c
+++ b/src/nautilus/msr.c
@@ -8,7 +8,7 @@
  * led by Sandia National Laboratories that includes several national 
  * laboratories and universities. You can find out more at:
  * http://www.v3vee.org  and
- * http://xtack.sandia.gov/hobbes
+ * http://xstack.sandia.gov/hobbes
  *
  * Copyright (c) 2015, Kyle C. Hale <kh@u.northwestern.edu>
  * Copyright (c) 2015, The V3VEE Project  <http://www.v3vee.org> 
@@ -20,7 +20,9 @@
  * This is free software.  You are permitted to use,
  * redistribute, and modify it as specified in the file "LICENSE.txt".
  */
+#include <nautilus/nautilus.h>
 #include <nautilus/msr.h>
+#include <nautilus/shell.h>
 
 
 inline void 
@@ -41,3 +43,65 @@ msr_read (uint32_t msr)
 }
 
 
+static int
+handle_wrmsr (char * buf, void * priv)
+{
+    uint32_t msr;
+    uint64_t data;
+
+    if (sscanf(buf, "wrmsr %x %lx",&msr,&data)==2) { 
+        msr_write(msr,data);
+        nk_vc_printf("MSR[0x%08x] = 0x%016lx\n",msr,data);
+        return 0;
+    }
+
+    nk_vc_printf("unknown wrmsr request\n");
+
+    return 0;
+}
+
+
+static int
+handle_rdmsr (char * buf, void * priv)
+{
+    uint32_t msr;
+    uint64_t size;
+    uint64_t data;
+
+    if ((sscanf(buf,"rdmsr %x %lu", &msr, &size)==2) ||
+            (size=1, sscanf(buf,"rdmsr %x", &msr)==1)) {
+        uint64_t i,k;
+        for (i=0;i<size;i++) { 
+            data = msr_read(msr+i);
+            nk_vc_printf("MSR[0x%08x] = 0x%016lx ",(uint32_t)(msr+i),data);
+            for (k=0;k<8;k++) { 
+                nk_vc_printf("%02x",*(k + (uint8_t*)&data));
+            }
+            nk_vc_printf(" ");
+            for (k=0;k<8;k++) { 
+                nk_vc_printf("%c",isalnum(*(k + (uint8_t*)&data)) ?
+                        (*(k + (uint8_t*)&data)) : '.');
+            }
+            nk_vc_printf("\n");
+        }
+        return 0;
+    }
+
+    nk_vc_printf("unknown rdmsr request\n");
+
+    return 0;
+}
+
+static struct shell_cmd_impl rdmsr_impl = {
+    .cmd      = "rdmsr",
+    .help_str = "rdmsr x [n]",
+    .handler  = handle_rdmsr,
+};
+nk_register_shell_cmd(rdmsr_impl);
+
+static struct shell_cmd_impl wrmsr_impl = {
+    .cmd      = "wrmsr",
+    .help_str = "wrmsr x y",
+    .handler  = handle_wrmsr,
+};
+nk_register_shell_cmd(wrmsr_impl);

--- a/src/nautilus/mtrr.c
+++ b/src/nautilus/mtrr.c
@@ -762,7 +762,7 @@ handle_mt (char * buf, void * priv)
 }
 
 static struct shell_cmd_impl mt_impl = {
-    .cmd      = "mt ",
+    .cmd      = "mt",
     .help_str = "mt addr",
     .handler  = handle_mt,
 };

--- a/src/nautilus/pmc.c
+++ b/src/nautilus/pmc.c
@@ -26,6 +26,7 @@
 #include <nautilus/cpuid.h>
 #include <nautilus/pmc.h>
 #include <nautilus/mm.h>
+#include <nautilus/shell.h>
 
 
 /*
@@ -887,7 +888,7 @@ nk_pmc_init (struct naut_info * naut)
 }
 
 
-void
+static void
 test_pmc (int pmc_id)
 {
     uint64_t start, stop;
@@ -920,3 +921,27 @@ test_pmc (int pmc_id)
 
     PMC_INFO("  Count reported: %lld\n", stop-start);
 }
+
+
+static int
+handle_pmc (char * buf, void * priv)
+{
+    int pmc_id;
+
+    if (sscanf(buf, "pmctest %d", &pmc_id) == 1) {
+        test_pmc(pmc_id);
+        return 0;
+    }
+
+    nk_vc_printf("Unknown PMC test\n");
+
+    return 0;
+}
+
+
+static struct shell_cmd_impl pmc_impl = {
+    .cmd      = "pmctest",
+    .help_str = "pmctest id",
+    .handler  = handle_pmc,
+};
+nk_register_shell_cmd(pmc_impl);

--- a/src/nautilus/prog.c
+++ b/src/nautilus/prog.c
@@ -27,6 +27,7 @@
 #include <nautilus/naut_string.h>
 #include <nautilus/prog.h>
 #include <nautilus/linker.h>
+#include <nautilus/shell.h>
 
 #ifndef NAUT_CONFIG_DEBUG_LINKER
 #undef DEBUG_PRINT
@@ -162,8 +163,8 @@ prog_info (struct naut_info * naut)
 }
 
 
-int
-handle_prog_cmd (char * buf)
+static int
+handle_prog (char * buf, void * priv)
 {
     buf += 4;
 
@@ -185,3 +186,9 @@ handle_prog_cmd (char * buf)
 }
 
 
+static struct shell_cmd_impl prog_impl = {
+    .cmd      = "prog",
+    .help_str = "prog run | prog info",
+    .handler  = handle_prog,
+};
+nk_register_shell_cmd(prog_impl);

--- a/src/nautilus/semaphore.c
+++ b/src/nautilus/semaphore.c
@@ -25,6 +25,7 @@
 #include <nautilus/thread.h>
 #include <nautilus/scheduler.h>
 #include <nautilus/semaphore.h>
+#include <nautilus/shell.h>
 
 // This is a trival implementation of classic semaphores for threads ONLY
 // interrupts can use the try functions only
@@ -342,3 +343,18 @@ void nk_semaphore_dump_semaphores()
     STATE_UNLOCK();
 }
 
+
+static int
+handle_sems (char * buf, void * priv)
+{
+    nk_semaphore_dump_semaphores();
+    return 0;
+}
+
+
+static struct shell_cmd_impl sems_impl = {
+    .cmd      = "sems",
+    .help_str = "sems",
+    .handler  = handle_sems,
+};
+nk_register_shell_cmd(sems_impl);

--- a/src/nautilus/shell.c
+++ b/src/nautilus/shell.c
@@ -15,1995 +15,443 @@
  *                     The Hobbes Project <http://xstack.sandia.gov/hobbes>
  * All rights reserved.
  *
- * Author: Peter Dinda <pdinda@u.northwestern.edu>
- *
+ * Authors: Peter Dinda <pdinda@northwestern.edu>
+ *          Kyle Hale <khale@cs.iit.edu>
+ *         
  * This is free software.  You are permitted to use,
  * redistribute, and modify it as specified in the file "LICENSE.txt".
  */
-
 #include <nautilus/nautilus.h>
 #include <nautilus/shell.h>
-#include <nautilus/libccompat.h>
 #include <nautilus/vc.h>
-#include <nautilus/dev.h>
-#include <nautilus/blkdev.h>
-#include <nautilus/netdev.h>
-#include <nautilus/chardev.h>
-#include <nautilus/semaphore.h>
-#include <nautilus/msg_queue.h>
-#include <nautilus/timer.h>
-#include <nautilus/fs.h>
-#include <nautilus/loader.h>
-#include <nautilus/cpuid.h>
-#include <nautilus/msr.h>
-#include <nautilus/mtrr.h>
-#include <nautilus/backtrace.h>
-#include <nautilus/pmc.h>
-#include <nautilus/linker.h>
-#include <nautilus/prog.h>
-#include <dev/gpio.h>
-#include <dev/pci.h>
-#include <dev/apic.h>
-#include <test/ipi.h>
-#include <test/threads.h>
-#include <test/groups.h>
-#include <test/tasks.h>
-#include <test/net_udp_echo.h>
 
-#ifdef NAUT_CONFIG_PALACIOS
-#include <nautilus/vmm.h>
+#ifndef NAUT_CONFIG_DEBUG_SHELL
+#undef DEBUG_PRINT
+#define DEBUG_PRINT(fmt, args...) 
 #endif
 
-#ifdef NAUT_CONFIG_REAL_MODE_INTERFACE 
-#include <nautilus/realmode.h>
-#endif
-
-#ifdef NAUT_CONFIG_ISOCORE
-#include <nautilus/isocore.h>
-#endif
-
-#ifdef NAUT_CONFIG_CACHEPART
-#include <nautilus/cachepart.h>
-#ifdef NAUT_CONFIG_TEST_CACHEPART
-#include <test/cachepart.h>
-#endif
-#endif
-
-#ifdef NAUT_CONFIG_ENABLE_BDWGC
-#include <gc/bdwgc/bdwgc.h>
-#endif
-
-#ifdef NAUT_CONFIG_ENABLE_PDSGC
-#include <gc/pdsgc/pdsgc.h>
-#endif
-
-#ifdef NAUT_CONFIG_LOAD_LUA
-#include <lua/lua.h>
-#include <lua/lualib.h>
-#include <lua/lauxlib.h>
-#include <dev/lua_script.h>
-#endif
-
-#ifdef NAUT_CONFIG_ENABLE_REMOTE_DEBUGGING
-#include <nautilus/gdb-stub.h>
-#endif
-
-#ifdef NAUT_CONFIG_PROFILE
-#include <nautilus/instrument.h>
-#endif
-
-
-#ifdef NAUT_CONFIG_OMP_RT_TESTS
-#include <test/test_omp.h>
-#endif
-
-#ifdef NAUT_CONFIG_NDPC_RT_TESTS
-#include <test/test_ndpc.h>
-#endif
-
-#ifdef NAUT_CONFIG_NESL_RT
-#include <rt/nesl/nesl.h>
-#endif
-
-#ifdef NAUT_CONFIG_NESL_RT_TESTS
-#include <test/test_nesl.h>
-#endif
-
-
-#ifdef NAUT_CONFIG_NET_ETHERNET
-#include <net/ethernet/ethernet_agent.h>
-#include <net/ethernet/ethernet_arp.h>
-#endif
-
-#ifdef NAUT_CONFIG_NET_LWIP
-#include <net/lwip/lwip.h>
-#endif
-
-
-#define MAX_CMD 80
-
-#define SHELL_STACK_SIZE (PAGE_SIZE_2MB) 
-
-struct burner_args {
-    struct nk_virtual_console *vc;
-    char     name[MAX_CMD];
-    uint64_t size_ns; 
-    struct nk_sched_constraints constraints;
-} ;
-
-// enable this to flip a GPIO periodically within
-// the main loop of test thread
-#define GPIO_OUTPUT 0
-
-#if GPIO_OUPUT
-#define GET_OUT() inb(0xe010)
-#define SET_OUT(x) outb(x,0xe010)
-#else
-#define GET_OUT() 
-#define SET_OUT(x) 
-#endif
-
-#define SWITCH() SET_OUT(~GET_OUT())
-#define LOOP() {SWITCH(); udelay(1000); }
-
-static void burner(void *in, void **out)
-{
-    uint64_t start, end, dur;
-    struct burner_args *a = (struct burner_args *)in;
-
-    nk_thread_name(get_cur_thread(),a->name);
-
-    if (nk_bind_vc(get_cur_thread(), a->vc)) { 
-	ERROR_PRINT("Cannot bind virtual console for burner %s\n",a->name);
-	return;
-    }
-
-    nk_vc_printf("%s (tid %llu) attempting to promote itself\n", a->name, get_cur_thread()->tid);
-#if 1
-    if (nk_sched_thread_change_constraints(&a->constraints)) { 
-	nk_vc_printf("%s (tid %llu) rejected - exiting\n", a->name, get_cur_thread()->tid);
-	return;
-    }
-#endif
-
-    nk_vc_printf("%s (tid %llu) promotion complete - spinning for %lu ns\n", a->name, get_cur_thread()->tid, a->size_ns);
-
-    while(1) {
-	NK_GPIO_OUTPUT_MASK(0x1, GPIO_XOR);
-	start = nk_sched_get_realtime();
-	//LOOP();
-	udelay(10);
-	end = nk_sched_get_realtime();
-	dur = end - start;
-	//	nk_vc_printf("%s (tid %llu) start=%llu, end=%llu left=%llu\n",a->name,get_cur_thread()->tid, start, end,a->size_ns);
-	if (dur >= a->size_ns) { 
-	    nk_vc_printf("%s (tid %llu) done - exiting\n",a->name,get_cur_thread()->tid);
-	    free(in);
-	    return;
-	} else {
-	    a->size_ns -= dur;
-	}
-    }
-}
-
-static int launch_aperiodic_burner(char *name, uint64_t size_ns, uint32_t tpr, uint64_t priority)
-{
-    nk_thread_id_t tid;
-    struct burner_args *a;
-
-    a = malloc(sizeof(struct burner_args));
-    if (!a) { 
-	return -1;
-    }
-    
-    strncpy(a->name,name,MAX_CMD); a->name[MAX_CMD-1]=0;
-    a->vc = get_cur_thread()->vc;
-    a->size_ns = size_ns;
-    a->constraints.type=APERIODIC;
-    a->constraints.interrupt_priority_class = (uint8_t) tpr;
-    a->constraints.aperiodic.priority=priority;
-
-    if (nk_thread_start(burner, (void*)a , NULL, 1, PAGE_SIZE_4KB, &tid, 1)) { 
-	free(a);
-	return -1;
-    } else {
-	return 0;
-    }
-}
-
-static int launch_sporadic_burner(char *name, uint64_t size_ns, uint32_t tpr, uint64_t phase, uint64_t size, uint64_t deadline, uint64_t aperiodic_priority)
-{
-    nk_thread_id_t tid;
-    struct burner_args *a;
-
-    a = malloc(sizeof(struct burner_args));
-    if (!a) { 
-	return -1;
-    }
-    
-    strncpy(a->name,name,MAX_CMD); a->name[MAX_CMD-1]=0;
-    a->vc = get_cur_thread()->vc;
-    a->size_ns = size_ns;
-    a->constraints.type=SPORADIC;
-    a->constraints.interrupt_priority_class = (uint8_t) tpr;
-    a->constraints.sporadic.phase = phase;
-    a->constraints.sporadic.size = size;
-    a->constraints.sporadic.deadline = deadline;
-    a->constraints.sporadic.aperiodic_priority = aperiodic_priority;
-
-    if (nk_thread_start(burner, (void*)a , NULL, 1, PAGE_SIZE_4KB, &tid, 1)) {
-	free(a);
-	return -1;
-    } else {
-	return 0;
-    }
-}
-
-static int launch_periodic_burner(char *name, uint64_t size_ns, uint32_t tpr, uint64_t phase, uint64_t period, uint64_t slice)
-{
-    nk_thread_id_t tid;
-    struct burner_args *a;
-
-    a = malloc(sizeof(struct burner_args));
-    if (!a) { 
-	return -1;
-    }
-    
-    strncpy(a->name,name,MAX_CMD); a->name[MAX_CMD-1]=0;
-    a->vc = get_cur_thread()->vc;
-    a->size_ns = size_ns;
-    a->constraints.type=PERIODIC;
-    a->constraints.interrupt_priority_class = (uint8_t) tpr;
-    a->constraints.periodic.phase = phase;
-    a->constraints.periodic.period = period;
-    a->constraints.periodic.slice = slice;
-
-    if (nk_thread_start(burner, (void*)a , NULL, 1, PAGE_SIZE_4KB, &tid, 1)) {
-	free(a);
-	return -1;
-    } else {
-	return 0;
-    }
-}
-
-
-static int handle_cat(char *buf)
-{
-    char data[MAX_CMD];
-    ssize_t ct, i;
-
-    buf+=3;
-    
-    while (*buf && *buf==' ') { buf++;}
-    
-    if (!*buf) { 
-	nk_vc_printf("No file requested\n");
-	return 0;
-    }
-
-    nk_fs_fd_t fd = nk_fs_open(buf,O_RDONLY,0);
-
-    if (FS_FD_ERR(fd)) { 
-	nk_vc_printf("Cannot open \"%s\"\n",buf);
-	return 0;
-    }
-
-    do {
-	ct = nk_fs_read(fd, data, MAX_CMD);
-	if (ct<0) {
-	    nk_vc_printf("Error reading file\n");
-	    nk_fs_close(fd);
-	    return 0;
-	}
-	for (i=0;i<ct;i++) {
-	    nk_vc_printf("%c",data[i]);
-	}
-    } while (ct>0);
-
-    //    nk_fs_close(fd);
-    
-    return 0;
-}
-
-#ifdef NAUT_CONFIG_REAL_MODE_INTERFACE 
-static int handle_real(char *cmd)
-{
-    struct nk_real_mode_int_args test;
-
-
-    if ((nk_real_mode_set_arg_defaults(&test),
-	 sscanf(cmd,"real %hx %hx %hx %hx %hx %hx:%hx", 
-		&test.vector, &test.ax, &test.bx, &test.cx, &test.cx, &test.es, &test.di)==7) ||
-	(nk_real_mode_set_arg_defaults(&test),
-	 sscanf(cmd,"real %hx %hx %hx %hx %hx:%hx", 
-		&test.vector, &test.ax, &test.bx, &test.cx, &test.es, &test.di)==6) ||
-	(nk_real_mode_set_arg_defaults(&test),
-	 sscanf(cmd,"real %hx %hx %hx %hx:%hx", 
-		&test.vector, &test.ax, &test.bx, &test.es, &test.di)==5) ||
-	(nk_real_mode_set_arg_defaults(&test),
-	 sscanf(cmd,"real %hx %hx %hx:%hx", 
-		&test.vector, &test.ax, &test.es, &test.di)==4) ||
-	(nk_real_mode_set_arg_defaults(&test),
-	 sscanf(cmd,"real %hx %hx:%hx", 
-		&test.vector, &test.ax, &test.es, &test.di)==3) ||
-	(nk_real_mode_set_arg_defaults(&test),
-	 sscanf(cmd,"real %hx %hx %hx %hx %hx", 
-		&test.vector, &test.ax, &test.bx, &test.cx, &test.dx)==5) ||
-	(nk_real_mode_set_arg_defaults(&test),
-	 sscanf(cmd,"real %hx %hx %hx %hx", 
-		&test.vector, &test.ax, &test.bx, &test.cx)==4) ||
-	(nk_real_mode_set_arg_defaults(&test),
-	 sscanf(cmd,"real %hx %hx %hx", 
-		&test.vector, &test.ax, &test.bx)==3) ||
-	(nk_real_mode_set_arg_defaults(&test),
-	 sscanf(cmd,"real %hx %hx", 
-		&test.vector, &test.ax)==2) ||	
-	(nk_real_mode_set_arg_defaults(&test),
-	 sscanf(cmd,"real %hx",
-		&test.vector)==1)) {
-
-	nk_vc_printf("Req: int %hx ax=%04hx bx=%04hx cx=%04hx dx=%04hx es:di=%04hx:%04hx\n",
-		     test.vector, test.ax, test.bx, test.cx, test.dx, test.es, test.di);
-    
-	if (nk_real_mode_start()) { 
-	    nk_vc_printf("start failed\n");
-	    return -1;
-	} else {
-	    if (nk_real_mode_int(&test)) { 
-		nk_vc_printf("int failed\n");
-		nk_real_mode_finish();
-		return -1;
-	    } else {
-		nk_vc_printf("Res: ax=%04hx bx=%04hx cx=%04hx dx=%04hx si=%04hx di=%04hx\n"
-			     "     flags=%04hx cs=%04hx ds=%04hx ss=%04hx fs=%04hx gs=%04hx es=%04hx\n",
-			     test.ax, test.bx, test.cx, test.dx, test.si, test.di,
-			     test.flags, test.cs, test.ds, test.ss, test.fs, test.gs, test.es);
-		nk_real_mode_finish();
-		return 0;
-	    }
-	}
-    } else {
-	nk_vc_printf("Don't understand %s\n",cmd);
-	return -1;
-    }
-}
-#endif
-
-
-static int handle_ipitest(char * buf)
-{
-	uint32_t trials, sid, did;
-
-	ipi_exp_data_t * data = malloc(sizeof(ipi_exp_data_t));
-	if (!data) {
-		nk_vc_printf("ERROR: could not allocate IPI experiment data\n");
-		return -1;
-	}
-	memset(data, 0, sizeof(ipi_exp_data_t));
-	
-	buf += 7;
-	while (*buf && *buf==' ') { buf++;}
-
-	if (!*buf) {
-		nk_vc_printf("No test type given\n");
-		return 0;
-	}
-
-	// get the experiment type (oneway, roundtrip, or broadcast)
-	if (sscanf(buf, "oneway %u", &trials)==1) {
-		data->type = EXP_ONEWAY;
-		buf += 6;
-	} else if (sscanf(buf, "roundtrip %u", &trials)==1) {
-		data->type = EXP_ROUNDTRIP;
-		buf += 9;
-	} else if (sscanf(buf, "broadcast %u", &trials)==1) {
-		data->type = EXP_BROADCAST;
-		buf += 9;
-	} else {
-		nk_vc_printf("Unknown IPI test type\n");
-		return 0;
-	}
-
-	data->trials = (trials > IPI_MAX_TRIALS) ? IPI_MAX_TRIALS : trials;
-
-    buf++;
-
-    // skip over trial count
-    while (*buf && *buf!=' ') { buf++;}
-
-    // find next arg
-	while (*buf && *buf==' ') { buf++;}
-
-    if (!strncasecmp(buf, "-f", 2)) {
-
-#ifndef NAUT_CONFIG_EXT2_FILESYSTEM_DRIVER 
-        nk_vc_printf("Not compiled with FS support, cannot use -f\n");
-        return 0;
-    }
-#else
-        char fbuf[IPI_MAX_FNAME_LEN];
-        data->use_file = 1;
-        buf += 2;
-
-        // find next arg
-        while (*buf && *buf==' ') { buf++;}
-
-        if (sscanf(buf, "%s", fbuf)==1) {
-            if (!strncasecmp(buf, "-", 1)) {
-                nk_vc_printf("No filename given\n");
-                return 0;
-            }
-            strncpy(data->fname, fbuf, IPI_MAX_FNAME_LEN);
-
-            // skip over the filename
-            while(*buf && *buf!=' ') {buf++;}
-
-            // find next arg
-            while (*buf && *buf==' ') {buf++;}
-
-        } else {
-            nk_vc_printf("No filename given\n");
-            return 0;
-        }
-    }
-#endif
-
-    // which source type is it 
-	if (sscanf(buf, "-s %u", &sid)==1) {
-        data->src_type = SRC_ONE;
-        data->src_core = sid; 
-        buf += 3;
-
-        // skip over src core
-        while (*buf && *buf!=' ') { buf++;}
-
-        // find next arg
-        while (*buf && *buf==' ') { buf++;}
-
-	} else { 
-        data->src_type = SRC_ALL;
-    }
-
-        
-    if (sscanf(buf, "-d %u", &did)==1) {
-        data->dst_type = DST_ONE;
-        data->dst_core = did;
-    } else {
-        data->dst_type = DST_ALL;
-    }
-		
-	if (ipi_run_exps(data) != 0) {
-        nk_vc_printf("Could not run ipi experiment\n");
-        return 0;
-    }
-
-    free(data);
-
-	return 0;
-}
-
-
-static int handle_blktest(char * buf)
-{
-    char name[32], rw[16];
-    uint64_t start, count;
-    struct nk_block_dev *d;
-    struct nk_block_dev_characteristics c;
-
-    if ((sscanf(buf,"blktest %s %s %lu %lu",name,rw,&start,&count)!=4)
-	|| (*rw!='r' && *rw!='w') ) { 
-	nk_vc_printf("Don't understand %s\n",buf);
-	return -1;
-    }
-
-    if (!(d=nk_block_dev_find(name))) { 
-	nk_vc_printf("Can't find %s\n",name);
-	return -1;
-    }
-
-    if (nk_block_dev_get_characteristics(d,&c)) { 
-	nk_vc_printf("Can't get characteristics of %s\n",name);
-	return -1;
-    }
-
-    char data[c.block_size+1];
-    uint64_t i,j;
-
-
-    for (i=start;i<start+count;i++) { 
-	if (*rw == 'w') { 
-	    for (j=0;j<c.block_size;j++) { 
-		data[j] = "abcdefghijklmnopqrstuvwxyz0123456789"[j%36];
-	    }
-	    if (nk_block_dev_write(d,i,1,data,NK_DEV_REQ_BLOCKING,0,0)) {
-		nk_vc_printf("Failed to write block %lu\n",i);
-		return -1;
-	    }
-	} else if (*rw == 'r') {
-	    if (nk_block_dev_read(d,i,1,data,NK_DEV_REQ_BLOCKING,0,0)) {
-		nk_vc_printf("Failed to read block %lu\n",i);
-		return -1;
-	    }
-	    data[c.block_size] = 0;
-	    nk_vc_printf("%s\n",data);
-	}
-    }
-    return 0;
-}
-
-static int test_stop()
-{
-    int i;
-
-#define N 16
-    
-    for (i=0;i<N;i++) { 
-	nk_vc_printf("Stopping world iteration %d\n",i);
-	nk_sched_stop_world();
-	nk_vc_printf("Executing during stopped world iteration %d\n",i);
-	nk_sched_start_world();
-    }
-
-    return 0;
-
-}
-
-#ifdef NAUT_CONFIG_ISOCORE
-
-static void isotest(void *arg)
-{
-    // note trying to do anything in here with NK
-    // features, even a print, is unlikely to work due to
-    // relocation, interrupts off, etc.   
-    //serial_print("Hello from isocore, my arg is %p\n", arg);
-    serial_putchar('H');
-    serial_putchar('I');
-    serial_putchar('!');
-    serial_putchar('\n');
-    while (1) { }  // does actually get here in testing
-}
-
-static int test_iso()
-{
-    void (*code)(void*) = isotest;
-    uint64_t codesize = PAGE_SIZE_4KB; // we are making pretend here
-    uint64_t stacksize = PAGE_SIZE_4KB;
-    void *arg = (void*)0xdeadbeef;
-
-    nk_vc_printf("Testing isolated core - this will not return!\n");
-
-    return nk_isolate(code, 
-		      codesize,
-		      stacksize,
-		      arg);
-}
-
-
-#endif
-
-#ifdef NAUT_CONFIG_GARBAGE_COLLECTION
-static int handle_collect(char *buf)
-{
-#ifdef NAUT_CONFIG_ENABLE_BDWGC
-    nk_vc_printf("Doing BDWGC global garbage collection\n");
-    int rc = nk_gc_bdwgc_collect();
-    nk_vc_printf("BDWGC global garbage collection done result: %d\n",rc);
-    return 0;
-#else
-#ifdef NAUT_CONFIG_ENABLE_PDSGC
-    nk_vc_printf("Doing PDSGC global garbage collection\n");
-    struct nk_gc_pdsgc_stats s;
-    int rc = nk_gc_pdsgc_collect(&s);
-    nk_vc_printf("PDSGC global garbage collection done result: %d\n",rc);
-    nk_vc_printf("%lu blocks / %lu bytes freed\n",
-		 s.num_blocks, s.total_bytes);
-    nk_vc_printf("smallest freed block: %lu bytes, largest freed block: %lu bytes\n",
-		 s.min_block, s.max_block);
-    return 0;
-#else 
-    nk_vc_printf("No garbage collector is enabled...\n");
-    return 0;
-#endif
-#endif
-}
-
-static int handle_leaks(char *buf)
-{
-#ifdef NAUT_CONFIG_ENABLE_BDWGC
-    nk_vc_printf("Leak detection not available for BDWGC\n");
-    return 0;
-#else
-#ifdef NAUT_CONFIG_ENABLE_PDSGC
-    nk_vc_printf("Doing PDSGC global leak detection\n");
-    struct nk_gc_pdsgc_stats s;
-    int rc = nk_gc_pdsgc_leak_detect(&s);
-    nk_vc_printf("PDSGC global leak detection done result: %d\n",rc);
-    nk_vc_printf("%lu blocks / %lu bytes have leaked\n",
-		 s.num_blocks, s.total_bytes);
-    nk_vc_printf("smallest leaked block: %lu bytes, largest leaked block: %lu bytes\n",
-		 s.min_block, s.max_block);
-    return 0;
-#else 
-    nk_vc_printf("No garbage collector is enabled...\n");
-    return 0;
-#endif
-#endif
-}
-#endif
-
-static int handle_test(char *buf)
-{
-    char what[80];
-    
-    if (sscanf(buf,"test %s",what)!=1) { 
-	goto dunno;
-    }
-
-#ifdef NAUT_CONFIG_OMP_RT_TESTS
-    if (!strncasecmp(what,"ompb",4)) { 
-	return test_ompbench();
-    }
-
-    if (!strncasecmp(what,"omp",3)) { 
-	return test_omp();
-    }
-#endif
-
-#ifdef NAUT_CONFIG_NDPC_RT_TESTS
-    if (!strncasecmp(what,"ndpc",4)) { 
-	return test_ndpc();
-    }
-#endif
-
-#ifdef NAUT_CONFIG_NESL_RT_TESTS
-    if (!strncasecmp(what,"nesl",4)) {
-	return test_nesl();
-    }
-#endif
-
-    if (!strncasecmp(what,"thread",6)) { 
-	return test_threads();
-    }
-
-    if (!strncasecmp(what,"group",5)) {
-        return nk_thread_group_test();
-    }
-
-    if (!strncasecmp(what,"task",4)) {
-        return test_tasks();
-    }
-
-    if (!strncasecmp(what,"stop",4)) { 
-	return test_stop();
-    }
-
-#ifdef NAUT_CONFIG_ISOCORE
-    if (!strncasecmp(what,"iso",3)) { 
-	test_iso();
-	return 0;
-    }
-#endif
-
-    int pmc_id;
-    if (sscanf(buf, "test pmc %d", &pmc_id) == 1) {
-        test_pmc(pmc_id);
-        return 0;
-    }
-
-#ifdef NAUT_CONFIG_TEST_BDWGC
-    if (!strncasecmp(what,"bdwgc",5)) { 
-	nk_vc_printf("Testing BDWGC garbage collector\n");
-	return nk_gc_bdwgc_test();
-    }
-#endif
-
-#ifdef NAUT_CONFIG_ENABLE_PDSGC
-    if (!strncasecmp(what,"pdsgc",5)) { 
-	nk_vc_printf("Testing PDSGC garbage collector\n");
-	return nk_gc_pdsgc_test();
-    }
-#endif
-
-#ifdef NAUT_CONFIG_TEST_CACHEPART
-    uint64_t size, iteration;
-    int percent, flag, num_threads, shared;
-
-    if (sscanf(buf, "test cachepart %lu %lu %d %d %d", &size, &iteration, &percent, &num_threads, &shared) == 5) {
-      nk_vc_printf("Testing cache partitioning with multiple threads\n");
-      test_cat_multi_threads(size, iteration, percent, num_threads, shared);
-      return 0;
-    }
-
-    if (sscanf(buf, "test cachepart %lu %lu %d", &size, &iteration, &percent) == 3) {
-      nk_vc_printf("Testing cache partitioning with a single thread\n");
-      test_cat_single_thread(size, iteration, percent);
-      return 0;
-    }
-
-#endif
-
-    char nic[80];
-    char ip[80];
-    uint32_t port, num;
-    
-    if (sscanf(buf,"test udp_echo %s %s %u %u",nic,ip,&port,&num)==4) { 
-	nk_vc_printf("Testing udp echo server\n");
-	test_net_udp_echo(nic,ip,port,num);
-	return 0;
-    } 
-
-    if (sscanf(buf,"test udp_echo %s",nic)==1) { 
-	nk_vc_printf("Testing udp echo server\n");
-	test_net_udp_echo(nic,"10.10.10.10",5000,20);
-	return 0;
-    }
-
- dunno:
-    nk_vc_printf("Unknown test request\n");
-    return -1;
-}
-	
-static int handle_attach(char * buf)
-{
-    char type[32], devname[32], fsname[32]; 
-    uint64_t start, count;
-    struct nk_block_dev *d;
-    struct nk_block_dev_characteristics c;
-    int rc;
-
-    if (sscanf(buf,"attach %s %s %s",devname, type, fsname)!=3) {
-	nk_vc_printf("Don't understand %s\n",buf);
-	return -1;
-    }
-
-    if (!strcmp(type,"ext2")) { 
-#ifndef NAUT_CONFIG_EXT2_FILESYSTEM_DRIVER 
-        nk_vc_printf("Not compiled with EXT2 support, cannot attach\n");
-        return -1;
-#else
-	if (nk_fs_ext2_attach(devname,fsname,0)) {
-	    nk_vc_printf("Failed to attach %s as ext2 volume with name %s\n", devname,fsname);
-	    return -1;
-	} else {
-	    nk_vc_printf("Device %s attached as ext2 volume with name %s\n", devname,fsname);
-	    return 0;
-	}
-#endif
-    } else {
-	nk_vc_printf("FS type %s is not supported\n", type);
-	return -1;
-    }
-}
-
-static int handle_benchmarks(char * buf)
-{
-    extern void run_benchmarks();
-    
-    run_benchmarks();
-
-    return 0;
-}
-
-
-static int handle_meminfo(char *buf)
-{
-    uint64_t num = kmem_num_pools();
-
-    // nk_vc_printf("Number of pools=%lu\n",num);
-    
-    struct kmem_stats *s = malloc(sizeof(struct kmem_stats)+num*sizeof(struct buddy_pool_stats));
-
-    if (!s) { 
-	nk_vc_printf("Failed to allocate space for mem info\n");
-	return 0;
-    }
-
-    s->max_pools = num;
-    
-    kmem_stats(s);
-
-    
-    uint64_t i;
-
-    for (i=0;i<s->num_pools;i++) { 
-	nk_vc_printf("pool %lu %p-%p %lu blks free %lu bytes free\n  %lu bytes min %lu bytes max\n", 
-		     i,
-		     s->pool_stats[i].start_addr,
-		     s->pool_stats[i].end_addr,
-		     s->pool_stats[i].total_blocks_free,
-		     s->pool_stats[i].total_bytes_free,
-		     s->pool_stats[i].min_alloc_size,
-		     s->pool_stats[i].max_alloc_size);
-    }
-
-    nk_vc_printf("%lu pools %lu blks free %lu bytes free\n", s->total_num_pools, s->total_blocks_free, s->total_bytes_free);
-    nk_vc_printf("  %lu bytes min %lu bytes max\n", s->min_alloc_size, s->max_alloc_size);
-
-    free(s);
-    
-    return 0;
-}
-
-int handle_run(char *buf)
-{
-    char path[80];
-
-    if (sscanf(buf,"run %s", path)!=1) { 
-	nk_vc_printf("Can't determine what to run\n");
-	return 0;
-    }
-
-    struct nk_exec *e = nk_load_exec(path);
-
-    if (!e) { 
-	nk_vc_printf("Can't load %s\n", path);
-	return 0;
-    }
-
-    nk_vc_printf("Loaded executable, now running\n");
-    
-    if (nk_start_exec(e,0,0)) { 
-	nk_vc_printf("Failed to run %s\n", path);
-    }
-
-    nk_vc_printf("Unloading executable\n");
-    
-    if (nk_unload_exec(e)) { 
-	nk_vc_printf("Failed to unload %s\n",path);
-    }
-
-    return 0;
-}    
-
-int handle_ioapic(char *buf)
-{
-    uint32_t num, pin;
-    struct sys_info *sys = &nk_get_nautilus_info()->sys;
-    struct ioapic *io;
-    char all[80];
-    char what[80];
-    int mask=0;
-
-    if (sscanf(buf,"ioapic %u %s %s",&num,all,what)==3) { 
-	if (num>=sys->num_ioapics) { 
-	    nk_vc_printf("unknown ioapic\n");
-	    return 0;
-	}
-	if (what[0]!='m' && what[0]!='u') { 
-	    nk_vc_printf("unknown ioapic request (mask|unmask)\n");
-	    return 0;
-	}
-	mask = what[0]=='m';
-	
-	if (all[0]!='a') { 
-	    if (sscanf(all,"%u",&pin)!=1) { 
-		nk_vc_printf("unknown ioapic request (pin|all)\n");
-		return 0;
-	    }
-	    if (mask) { 
-		nk_vc_printf("masking ioapic %u pin %u\n",num,pin);
-		ioapic_mask_irq(sys->ioapics[num], pin);
-	    } else {
-		nk_vc_printf("unmasking ioapic %u pin %u\n",num,pin);
-		ioapic_unmask_irq(sys->ioapics[num], pin);
-	    }
-	} else {
-	    for (pin=0;pin<sys->ioapics[num]->num_entries;pin++) { 
-		if (mask) { 
-		    nk_vc_printf("masking ioapic %u pin %u\n",num,pin);
-		    ioapic_mask_irq(sys->ioapics[num], pin);
-		} else {
-		    nk_vc_printf("unmasking ioapic %u pin %u\n",num,pin);
-		    ioapic_unmask_irq(sys->ioapics[num], pin);
-		}
-	    }
-	}
-	return 0;
-    }
-
-    if (sscanf(buf,"ioapic %s",what)==1) { 
-	if (what[0]=='l' || what[0]=='d') { 
-	    for (num=0;num<sys->num_ioapics;num++) {
-		io = sys->ioapics[num];
-		nk_vc_printf("ioapic %u: id=%u %u pins address=%p\n",
-			     num, io->id, io->num_entries, (void*)io->base);
-		if (what[0]=='d') { 
-		    uint64_t entry;
-		    for (pin=0;pin<io->num_entries;pin++) { 
-			entry = (uint64_t) ioapic_read_reg(io, 0x10 + 2*pin);
-			entry |= ((uint64_t) ioapic_read_reg(io, 0x10 + 2*pin+1));
-
-			nk_vc_printf("  pin %2u -> %016lx (dest 0x%lx mask %lu vec 0x%lx%s)\n", 
-				     pin, entry, (entry>>56)&0xffLU, (entry>>16)&0x1LU,
-				     entry&0xffLU, (entry&0xffLU) == 0xf7 ? " panic" : "");
-		    }
-		}
-	    }
-	    return 0;
-	} else {
-	    nk_vc_printf("Unknown ioapic request\n");
-	    return 0;
-	}				       
-    }
-    
-    nk_vc_printf("unknown ioapic request\n");
-    return 0;
-}
-
-	
-
-
-int handle_pci(char *buf)
-{
-  int bus, slot, func, off;
-  uint64_t data;
-  char bwdq; 
-
-  if (strncmp(buf,"pci l",5)==0) { 
-    pci_dump_device_list();
-    return 0;
-  }
-
-  if (sscanf(buf,"pci raw %x %x %x", &bus, &slot, &func)==3) { 
-    int i,j;
-    uint32_t v;
-    for (i=0;i<256;i+=32) {
-      nk_vc_printf("%02x:", i);
-      for (j=0;j<8;j++) {
-	v = pci_cfg_readl(bus,slot,func,i+j*4);
-	nk_vc_printf(" %08x",v);
-      } 
-      nk_vc_printf("\n");
-    }
-    return 0;
-  }
-
-  if (sscanf(buf,"pci dev %x %x %x", &bus, &slot, &func)==3) { 
-    pci_dump_device(pci_find_device(bus,slot,func));
-    return 0;
-  }
-
-
-
-  if (!strncmp(buf,"pci dev",7)) {
-    pci_dump_devices();
-    return 0;
-  }
-
-  if (((bwdq='w', sscanf(buf,"pci poke w %x %x %x %x %x", &bus, &slot, &func, &off,&data))==5) ||
-      ((bwdq='d', sscanf(buf,"pci poke d %x %x %x %x %x", &bus, &slot, &func, &off,&data))==5) ||
-      ((bwdq='d', sscanf(buf,"pci poke %x %x %x %x %x", &bus, &slot, &func, &off,&data))==5)) {
-      if (bwdq=='w') { 
-	  pci_cfg_writew(bus,slot,func,off,(uint16_t)data);
-	  nk_vc_printf("PCI[%x:%x.%x:%x] = 0x%04x\n",bus,slot,func,off,(uint16_t)data);
-      } else {
-	  pci_cfg_writel(bus,slot,func,off,(uint32_t)data);
-	  nk_vc_printf("PCI[%x:%x.%x:%x] = 0x%08x\n",bus,slot,func,off,(uint32_t)data);
-      }
-      return 0;
-  }
-
-  if (((bwdq='w', sscanf(buf,"pci peek w %x %x %x %x", &bus, &slot, &func, &off))==4) ||
-      ((bwdq='d', sscanf(buf,"pci peek d %x %x %x %x", &bus, &slot, &func, &off))==4) ||
-      ((bwdq='d', sscanf(buf,"pci peek %x %x %x %x", &bus, &slot, &func, &off))==4)) {
-      if (bwdq=='w') { 
-	  data = pci_cfg_readw(bus,slot,func,off);
-	  nk_vc_printf("PCI[%x:%x.%x:%x] = 0x%04x\n",bus,slot,func,off,(uint16_t)data);
-      } else {
-	  data = pci_cfg_readl(bus,slot,func,off);
-	  nk_vc_printf("PCI[%x:%x.%x:%x] = 0x%08x\n",bus,slot,func,off,(uint32_t)data);
-      }
-      return 0;
-  }
-
-  if (sscanf(buf,"pci cfg %x %x %x", &bus, &slot, &func)) {
-      int i,j;
-      uint8_t data[256];
-      for (i=0;i<256;i+=4) {
-	  *(uint32_t*)(&data[i]) = pci_cfg_readl(bus,slot,func,i);
-      }
-      for (i=0;i<256;i+=16) {
-	  nk_vc_printf("PCI[%x:%x.%x].cfg[%02x] = ",bus,slot,func,i);
-	  for (j=i;j<(i+16);j++) {
-	      nk_vc_printf(" %02x",data[j]);
-	  }
-	  nk_vc_printf("\n");
-      }
-      return 0;
-  }
-
-  nk_vc_printf("unknown pci command\n");
-
-  return -1;
-}    
-	
-#ifdef NAUT_CONFIG_PROFILE
-int handle_instrument(char *buf)
-{
-    char what[80];
-
-    if (sscanf(buf,"inst%s* %s", what)==1) { 
-	if (!strncasecmp(what,"sta",3)) {
-	    nk_vc_printf("starting instrumentation\n");
-	    nk_instrument_start();
-	    return 0;
-	} else if (!strncasecmp(what,"e",1) || !strncasecmp(what,"sto",3)) {
-	    nk_vc_printf("ending instrumentation\n");
-	    nk_instrument_end();
-	    return 0;
-	} else if (!strncasecmp(what,"c",1)) {
-	    nk_vc_printf("clearing instrumentation\n");
-	    nk_instrument_clear();
-	    return 0;
-	} else if (!strncasecmp(what,"q",1)) {
-	    nk_vc_printf("querying instrumentation\n");
-	    nk_instrument_query();
-	    return 0;
-	} 
-    }
-    nk_vc_printf("unknown instrumentation request\n");
-    return 0;
-}
-#endif
-
-	
-#ifdef NAUT_CONFIG_GPIO
-int handle_gpio(char *buf)
-{
-    char what[80];
-    uint64_t val;
-    uint64_t i;
-    int set = nk_gpio_cpu_mask_check(my_cpu_id());
-
-    if ((sscanf(buf,"gpio %s %lx", what, &val)==2) && what[0]=='s') {
-	nk_vc_printf("sweeping gpio output from 0 to %lx with ~10 us delay\n",val);
-	if (!set) {
-	    nk_gpio_cpu_mask_add(my_cpu_id());
-	}
-	for (i=0;i<val;i++) { 
-	    nk_gpio_output_set(i);
-	    udelay(10);
-	}
-	if (!set) {
-	    nk_gpio_cpu_mask_remove(my_cpu_id());
-	}
-	return 0;
-    }
-
-    if ((sscanf(buf,"gpio %s %lx", what, &val)==2) && what[0]=='o') {
-	nk_vc_printf("setting gpio output to %lx\n",val);
-	if (!set) {
-	    nk_gpio_cpu_mask_add(my_cpu_id());
-	}
-	nk_gpio_output_set(val);
-	if (!set) {
-	    nk_gpio_cpu_mask_remove(my_cpu_id());
-	}
-	return 0;
-    }
-
-    if ((sscanf(buf,"gpio %s",what)==1) && what[0]=='i') {
-	val = nk_gpio_input_get();
-	nk_vc_printf("gpio input is %llx\n",val);
-	return 0;
-    }
-
-    nk_vc_printf("unknown gpio request\n");
-
-    return 0;
-}
-#endif    
-
-static int handle_net(char *buf)
-{
-    char agentname[100], intname[100];
-    uint32_t type;
-    uint32_t ip[4];
-    uint32_t gw[4];
-    uint32_t netmask[4];
-    uint32_t dns[4];
-    int defaults=0;
-
-#ifdef NAUT_CONFIG_NET_ETHERNET
-    if (sscanf(buf,"net agent create %s %s",agentname, intname)==2) {
-	nk_vc_printf("Attempt to create ethernet agent %s for device %s\n",agentname, intname);
-	struct nk_net_dev *netdev = nk_net_dev_find(intname);
-	struct nk_net_ethernet_agent *agent;
-      
-	if (!netdev) {
-	    nk_vc_printf("Cannot find device %s\n",intname);
-	    return 0;
-	}
-
-	agent = nk_net_ethernet_agent_create(netdev, agentname, 64, 64);
-
-	if (!agent) {
-	    nk_vc_printf("Cannot create agent %s\n",agentname);
-	    return 0;
-	}
-
-	nk_vc_printf("agent created\n");
-	return 0;
-    }
-      
-
-    if (sscanf(buf,"net agent add %s %x",agentname, &type)==2) {
-	nk_vc_printf("Attempt to create interface for agent %s type %us\n", agentname,type);
-	struct nk_net_ethernet_agent *agent = nk_net_ethernet_agent_find(agentname);
-	struct nk_net_dev *netdev;
-	if (!agent) {
-	    nk_vc_printf("Cannot find agent %s\n", agentname);
-	    return 0;
-	}
-	netdev = nk_net_ethernet_agent_register_type(agent,type);
-	if (!netdev) {
-	    nk_vc_printf("Failed to register for type\n");
-	    return 0;
-	}
-	nk_vc_printf("New netdev is named: %s\n", netdev->dev.name);
-	return 0;
-    }
-  
-    if (sscanf(buf,"net agent s%s %s",buf,agentname)==2) {
-	struct nk_net_ethernet_agent *agent = nk_net_ethernet_agent_find(agentname);
-	if (!agent) {
-	    nk_vc_printf("Cannot find agent %s\n", agentname);
-	    return 0;
-	}
-	if (buf[0]=='t' && buf[1]=='o') {
-	    if (nk_net_ethernet_agent_stop(agent)) {
-		nk_vc_printf("Failed to to stop agent %s\n", agentname);
-	    } else {
-		nk_vc_printf("Stopped agent %s\n", agentname);
-	    }
-	} else if (buf[0]=='t' && buf[1]=='a') {
-	    if (nk_net_ethernet_agent_start(agent)) {
-		nk_vc_printf("Failed to to start agent %s\n", agentname);
-	    } else {
-		nk_vc_printf("Started agent %s\n", agentname);
-	    }
-	} else {
-	    nk_vc_printf("Unknown agent command\n");
-	}
-	return 0;
-    }
-	  
-
-  
-    if (sscanf(buf,"net arp create %s %u.%u.%u.%u",agentname,&ip[0],&ip[1],&ip[2],&ip[3])==5) {
-	ipv4_addr_t ipv4 = ip[0]<<24 | ip[1]<<16 | ip[2]<<8 | ip[3];
-	struct nk_net_ethernet_agent *agent = nk_net_ethernet_agent_find(agentname);
-	if (!agent) {
-	    nk_vc_printf("Cannot find agent %s\n", agentname);
-	    return 0;
-	}
-	struct nk_net_dev *netdev = nk_net_ethernet_agent_get_underlying_device(agent);
-	struct nk_net_dev_characteristics c;
-	struct nk_net_ethernet_arper *arper = nk_net_ethernet_arper_create(agent);
-	if (!arper) {
-	    nk_vc_printf("Failed to create arper\n");
-	    return 0;
-	}
-
-	nk_net_dev_get_characteristics(netdev,&c);
-      
-	if (nk_net_ethernet_arper_add(arper,ipv4,c.mac)) {
-	    nk_vc_printf("Failed to add ip->mac mapping\n");
-	    return 0;
-	}
-	nk_vc_printf("Added ip->mac mapping\n");
-	return 0;
-    }      
-
-    if (sscanf(buf,"net arp ask %u.%u.%u.%u",&ip[0],&ip[1],&ip[2],&ip[3])==4) {
-	ipv4_addr_t ipv4 = ip[0]<<24 | ip[1]<<16 | ip[2]<<8 | ip[3];
-	ethernet_mac_addr_t mac;
-	int rc = nk_net_ethernet_arp_lookup(0,ipv4,mac);
-	if (rc<0) {
-	    nk_vc_printf("Lookup failed\n");
-	} else if (rc==0) {
-	    nk_vc_printf("Lookup of %u.%u.%u.%u is %02x:%02x:%02x:%02x:%02x:%02x\n",
-			 ip[0],ip[1],ip[2],ip[3], mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
-	} else {
-	    nk_vc_printf("Lookup is in progress\n");
-	}
-	return 0;
-    }
-
-#endif
-
-#ifdef NAUT_CONFIG_NET_LWIP
-    if (sscanf(buf,"net lwip start %s", intname)==1 && !strncasecmp(intname,"defaults",8)) {
-	
-	struct nk_net_lwip_config conf = { .dns_ip = 0x08080808 } ;
-
-	if (nk_net_lwip_start(&conf)) {
-	    nk_vc_printf("Failed to start lwip\n");
-	    return 0;
-	}
-
-	struct nk_net_lwip_interface inter = { .name = "virtio-net0",
-					       .ipaddr = 0x0a0a0a0a,
-					       .netmask = 0xffffff00,
-					       .gateway = 0x0a0a0a01 };
-	
-
-	if (nk_net_lwip_add_interface(&inter)) {
-	    nk_vc_printf("Failed to add interface\n");
-	    return 0;
-	}
-
-	nk_vc_printf("LWIP started with defaults and default interface added\n");
-	return 0;
-    }
-
-    if (sscanf(buf,"net lwip start %u.%u.%u.%u", &dns[0], &dns[1], &dns[2], &dns[3])==4) {
-	
-	struct nk_net_lwip_config conf = { .dns_ip = dns[0]<<24 | dns[1]<<16 | dns[2]<<8 | dns[3] } ;
-
-	if (nk_net_lwip_start(&conf)) {
-	    nk_vc_printf("Failed to start lwip\n");
-	    return 0;
-	}
-
-	nk_vc_printf("LWIP started\n");
-	return 0;
-	
-    }
-
-	
-    if (sscanf(buf,"net lwip add %s %u.%u.%u.%u %u.%u.%u.%u %u.%u.%u.%u\n",
-	       &intname,
-	       &ip[0], &ip[1], &ip[2], &ip[3],
-	       &netmask[0], &netmask[1], &netmask[2], &netmask[3],
-	       &gw[0], &gw[1], &gw[2], &gw[3])==13) {
-
-	struct nk_net_lwip_interface inter;
-
-	strncpy(inter.name,intname,DEV_NAME_LEN); inter.name[DEV_NAME_LEN-1]=0;
-	inter.ipaddr = ip[0]<<24 | ip[1]<<16 | ip[2]<<8 | ip[3];
-	inter.netmask = netmask[0]<<24 | netmask[1]<<16 | netmask[2]<<8 | netmask[3];
-	inter.gateway = gw[0]<<24 | gw[1]<<16 | gw[2]<<8 | gw[3];
-	
-	
-	if (nk_net_lwip_add_interface(&inter)) {
-	    nk_vc_printf("Failed to add interface\n");
-	    return 0;
-	}
-
-	nk_vc_printf("added interface %s ip=%u.%u.%u.%u netmask=%u.%u.%u.%u gw=%u.%u.%u.%u\n",
-		     intname,ip[0],ip[1],ip[2],ip[3],netmask[0],netmask[1],netmask[2],netmask[3],
-		     gw[0],gw[1],gw[2],gw[3]);
-	
-	return 0;
-    }
-
-#ifdef NAUT_CONFIG_NET_LWIP_APP_ECHO
-    if (!strcasecmp(buf,"net lwip echo")) {
-	void echo_init();
-	nk_vc_printf("Starting echo server (port 7)\n");
-	echo_init();
-	return 0;
-    }
-#endif
-
-#ifdef NAUT_CONFIG_NET_LWIP_APP_HTTPD
-    if (!strcasecmp(buf,"net lwip httpd")) {
-	void httpd_init();
-	nk_vc_printf("Starting httpd (port 80)\n");
-	httpd_init();
-	return 0;
-    }
-#endif
-
-#ifdef NAUT_CONFIG_NET_LWIP_APP_LWIP_SHELL
-    if (!strcasecmp(buf,"net lwip shell")) {
-	void shell_init();
-	nk_vc_printf("Starting shell server (port 23)\n");
-	shell_init();
-	return 0;
-    }
-#endif
-
-#ifdef NAUT_CONFIG_NET_LWIP_APP_LWIP_SOCKET_ECHO
-    if (!strcasecmp(buf,"net lwip socket_echo")) {
-	void socket_echo_init();
-	nk_vc_printf("Starting socket_echo (port 7)\n");
-	socket_echo_init();
-	return 0;
-    }
-#endif
-
-#ifdef NAUT_CONFIG_NET_LWIP_APP_SOCKET_EXAMPLES
-    if (!strcasecmp(buf,"net lwip socket_examples")) {
-	void socket_examples_init();
-	nk_vc_printf("Starting socket_examples (outgoing)\n");
-	socket_examples_init();
-	return 0;
-    }
-#endif
-
-#ifdef NAUT_CONFIG_NET_LWIP_APP_LWIP_IPVCD
-    if (!strcasecmp(buf,"net lwip ipvcd")) {
-	void ipvcd_init();
-	nk_vc_printf("Starting Virtual Console Daemon (port 23)\n");
-	ipvcd_init();
-	return 0;
-    }
-#endif
-    
-#endif
-    
-    nk_vc_printf("No relevant network functionality is configured or bad command\n");
-    return 0;
-}
-
-
-static int handle_cmd(char *buf, int n)
-{
-  char name[MAX_CMD];
-  uint64_t size_ns;
-  uint32_t tpr;
-  uint64_t priority, phase;
-  uint64_t period, slice;
-  uint64_t size, deadline;
-  uint64_t addr, data, len;
-  uint64_t tid;
-  uint32_t id, idsub, sub;
-  uint32_t msr;
-  int cpu;
-  int intr;
-  char bwdq;
-
-  if (*buf==0) { 
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"exit",4)) { 
-    return 1;
-  }
-
-#ifdef NAUT_CONFIG_REAL_MODE_INTERFACE 
-  if (!strncasecmp(buf,"real",4)) { 
-    handle_real(buf);
-    return 0;
-  }
-#endif
-
- 
-  if (!strncasecmp(buf,"help",4)) { 
-    nk_vc_printf("help\nexit\nvcs\ncores [n]\ntime [n]\nthreads [n]\n");
-    nk_vc_printf("devs | sems | mqs | fses | ofs | cat [path]\n");
-#ifdef NAUT_CONFIG_PROFILE
-    nk_vc_printf("instrument start|end/stop|clear|query\n");
-#endif
-#ifdef NAUT_CONFIG_GPIO
-    nk_vc_printf("gpio in/out/sweep [val]\n");
-#endif
-    nk_vc_printf("delay us | sleep us\n");
-    nk_vc_printf("ioapic <list|dump> | ioapic num <pin|all> <mask|unmask>\n");
-    nk_vc_printf("pci list | pci raw/dev bus slot func | pci dev [bus slot func]\n");
-    nk_vc_printf("pci peek|poke bus slot func off [val] | pci cfg bus slot func\n");
-    nk_vc_printf("shell name\n");
-    nk_vc_printf("regs [t]\npeek [bwdq] x | mem x n [s] | mt x | poke [bwdq] x y\nin [bwd] addr | out [bwd] addr data\nrdmsr x [n] | wrmsr x y\ncpuid f [n] | cpuidsub f s | mtrrs [cpu] | int [cpu] v\n");
-    nk_vc_printf("meminfo [detail]\n");
-    nk_vc_printf("prog run | prog info\n");
-    nk_vc_printf("reap | net ...\n");
-#ifdef NAUT_CONFIG_CACHEPART
-    nk_vc_printf("cachepart\n");
-#endif
-#ifdef NAUT_CONFIG_GARBAGE_COLLECTION
-    nk_vc_printf("collect | leaks\n");
-#endif
-#ifdef NAUT_CONFIG_ENABLE_REMOTE_DEBUGGING
-    nk_vc_printf("break\n");
-#endif
-    
-    nk_vc_printf("burn a name size_ms tpr priority\n");
-    nk_vc_printf("burn s name size_ms tpr phase size deadline priority\n");
-    nk_vc_printf("burn p name size_ms tpr phase period slice\n");
-    nk_vc_printf("real int [ax [bx [cx [dx]]]] [es:di]\n");
-    nk_vc_printf("ipitest type (oneway | roundtrip | broadcast) trials [-f <filename>] [-s <src_id> | all] [-d <dst_id> | all]\n");
-    nk_vc_printf("bench\n");
-    nk_vc_printf("blktest dev r|w start count\n");
-    nk_vc_printf("blktest dev r|w start count\n");
-    nk_vc_printf("test threads|groups|tasks|stop|iso|bdwgc|pdsgc|omp|ompbench|ndpc|nesl|\n");
-    nk_vc_printf("     udp_echo nic ip port num|cachepart ... |pmc ... | ...\n"); 
-    nk_vc_printf("vm name [embedded image]\n");
-    nk_vc_printf("run path\n");
-    return 0;
-  }
-
-
-#ifdef NAUT_CONFIG_PROFILE
-  if (!strncasecmp(buf,"inst",4)) {
-      handle_instrument(buf);
-      return 0;
-  }
-#endif
-
-#ifdef NAUT_CONFIG_GPIO
-  if (!strncasecmp(buf,"gpio",4)) {
-      handle_gpio(buf);
-      return 0;
-  }
-#endif
-
-  if (!strncasecmp(buf,"net",3)) {
-      handle_net(buf);
-      return 0;
-  }
-
-  if (!strncasecmp(buf,"vcs",3)) {
-    nk_switch_to_vc_list();
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"devs",4)) {
-    nk_dev_dump_devices();
-    return 0;
-
-  }
-  
-  if (!strncasecmp(buf,"sems",4)) {
-    nk_semaphore_dump_semaphores();
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"mqs",3)) {
-    nk_msg_queue_dump_queues();
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"ioapic",6)) {
-    handle_ioapic(buf);
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"pci",3)) {
-    handle_pci(buf);
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"fses",4)) {
-    nk_fs_dump_filesystems();
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"ofs",3)) {
-    nk_fs_dump_files();
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"cat",3)) {
-    handle_cat(buf);
-    return 0;
-  }
-
-
-#ifdef NAUT_CONFIG_CACHEPART
-  if (!strncasecmp(buf,"cachepart",9)) {
-      nk_cache_part_dump();
-      return 0;
-  }
-#endif
-  
-  if (!strncasecmp(buf,"ipitest",7)) {
-	handle_ipitest(buf);
-	return 0;
-  }
-
-  if (!strncasecmp(buf,"bench",5)) {
-	handle_benchmarks(buf);
-	return 0;
-  }
-
-  if (!strncasecmp(buf,"blktest",7)) {
-	handle_blktest(buf);
-	return 0;
-  }
-
-  if (!strncasecmp(buf,"test",4)) {
-      handle_test(buf);
-      return 0;
-  }
-
-
-  if (!strncasecmp(buf,"attach",6)) {
-	handle_attach(buf);
-	return 0;
-  }
-
-  if (sscanf(buf,"shell %s", name)==1) { 
-    nk_launch_shell(name,-1,0,0); // simple interactive shell
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"reap",4)) { 
-    nk_sched_reap(1); // unconditional reap
-    return 0;
-  }
-
-#ifdef NAUT_CONFIG_GARBAGE_COLLECTION
-  if (!strncasecmp(buf,"collect",7)) { 
-      handle_collect(buf); 
-      return 0;
-  }
-#endif
-
-#ifdef NAUT_CONFIG_ENABLE_REMOTE_DEBUGGING
-  if (!strncasecmp(buf,"break",5)) {
-      nk_gdb_breakpoint_here();
-      return 0;
-  }
-#endif
-
-#ifdef NAUT_CONFIG_GARBAGE_COLLECTION
-  if (!strncasecmp(buf,"leak",4)) { 
-      handle_leaks(buf); 
-      return 0;
-  }
-#endif
-
-  uint64_t time_us;
-  
-  if (sscanf(buf,"delay %lu",&time_us)==1) {
-    nk_vc_printf("Delaying for %lu us\n", time_us);
-    nk_delay(time_us*1000UL);
-    return 0;
-  }
-
-  if (sscanf(buf,"sleep %lu",&time_us)==1) {
-    nk_vc_printf("Sleeping for %lu us\n", time_us);
-    nk_sleep(time_us*1000UL);
-    return 0;
-  }
-  
-  if (sscanf(buf,"regs %lu",&tid)==1) { 
-      nk_thread_t *t = nk_find_thread_by_tid(tid);
-      if (!t) {
-	  nk_vc_printf("No such thread\n");
-      } else {
-	  nk_print_regs((struct nk_regs *) t->rsp);
-      }
-      return 0;
-  }
-
-  if (!strncasecmp(buf,"regs",4)) {
-      extern int nk_interrupt_like_trampoline(void (*)(struct nk_regs *));
-      nk_interrupt_like_trampoline(nk_print_regs);
-      return 0;
-  }
-
-  if (((bwdq='b', sscanf(buf,"peek b %lx", &addr))==1) ||
-      ((bwdq='w', sscanf(buf,"peek w %lx", &addr))==1) ||
-      ((bwdq='d', sscanf(buf,"peek d %lx", &addr))==1) ||
-      ((bwdq='q', sscanf(buf,"peek q %lx", &addr))==1) ||
-      ((bwdq='q', sscanf(buf,"peek %lx", &addr))==1)) {
-      switch (bwdq) { 
-      case 'b': 
-	  data = *(uint8_t*)addr;       
-	  nk_vc_printf("Mem[0x%016lx] = 0x%02lx\n",addr,data);
-	  break;
-      case 'w': 
-	  data = *(uint16_t*)addr;       
-	  nk_vc_printf("Mem[0x%016lx] = 0x%04lx\n",addr,data);
-	  break;
-      case 'd': 
-	  data = *(uint32_t*)addr;       
-	  nk_vc_printf("Mem[0x%016lx] = 0x%08lx\n",addr,data);
-	  break;
-      case 'q': 
-	  data = *(uint64_t*)addr;       
-	  nk_vc_printf("Mem[0x%016lx] = 0x%016lx\n",addr,data);
-	  break;
-      default:
-	  nk_vc_printf("Unknown size requested\n",bwdq);
-	  break;
-      }
-      return 0;
-  }
-
-  if (((bwdq='b', sscanf(buf,"in b %lx", &addr))==1) ||
-      ((bwdq='w', sscanf(buf,"in w %lx", &addr))==1) ||
-      ((bwdq='d', sscanf(buf,"in d %lx", &addr))==1) ||
-      ((bwdq='b', sscanf(buf,"in %lx", &addr))==1)) {
-      addr &= 0xffff; // 16 bit address space
-      switch (bwdq) { 
-      case 'b': 
-	  data = (uint64_t) inb(addr);
-	  nk_vc_printf("IO[0x%04lx] = 0x%02lx\n",addr,data);
-	  break;
-      case 'w': 
-	  data = (uint64_t) inw(addr);
-	  nk_vc_printf("IO[0x%04lx] = 0x%04lx\n",addr,data);
-	  break;
-      case 'd': 
-	  data = (uint64_t) inl(addr);
-	  nk_vc_printf("IO[0x%04lx] = 0x%08lx\n",addr,data);
-	  break;
-      default:
-	  nk_vc_printf("Unknown size requested\n",bwdq);
-	  break;
-      }
-      return 0;
-  }
-
-#define BYTES_PER_LINE 16
-
-  if ((sscanf(buf, "mem %lx %lu %lu",&addr,&len,&size)==3) ||
-      (size=8, sscanf(buf, "mem %lx %lu", &addr, &len)==2)) { 
-      uint64_t i,j,k;
-      for (i=0;i<len;i+=BYTES_PER_LINE) {
-	  nk_vc_printf("%016lx :",addr+i);
-	  for (j=0;j<BYTES_PER_LINE && (i+j)<len; j+=size) {
-	      nk_vc_printf(" ");
-	      for (k=0;k<size;k++) { 
-		  nk_vc_printf("%02x", *(uint8_t*)(addr+i+j+k));
-	      }
-	  }
-	  nk_vc_printf(" ");
-	  for (j=0;j<BYTES_PER_LINE && (i+j)<len; j+=size) {
-	      for (k=0;k<size;k++) { 
-		  nk_vc_printf("%c", isalnum(*(uint8_t*)(addr+i+j+k)) ? 
-			       *(uint8_t*)(addr+i+j+k) : '.');
-	      }
-	  }
-	  nk_vc_printf("\n");
-      }	      
-
-      return 0;
-  }
-
-  if (((bwdq='b', sscanf(buf,"poke b %lx %lx", &addr,&data))==2) ||
-      ((bwdq='w', sscanf(buf,"poke w %lx %lx", &addr,&data))==2) ||
-      ((bwdq='d', sscanf(buf,"poke d %lx %lx", &addr,&data))==2) ||
-      ((bwdq='q', sscanf(buf,"poke q %lx %lx", &addr,&data))==2) ||
-      ((bwdq='q', sscanf(buf,"poke %lx %lx", &addr, &data))==2)) {
-      switch (bwdq) { 
-      case 'b': 
-	  *(uint8_t*)addr = data; clflush_unaligned((void*)addr,1);
-	  nk_vc_printf("Mem[0x%016lx] = 0x%02lx\n",addr,data);
-	  break;
-      case 'w': 
-	  *(uint16_t*)addr = data; clflush_unaligned((void*)addr,2);
-	  nk_vc_printf("Mem[0x%016lx] = 0x%04lx\n",addr,data);
-	  break;
-      case 'd': 
-	  *(uint32_t*)addr = data; clflush_unaligned((void*)addr,4);
-	  nk_vc_printf("Mem[0x%016lx] = 0x%08lx\n",addr,data);
-	  break;
-      case 'q': 
-	  *(uint64_t*)addr = data; clflush_unaligned((void*)addr,8);
-	  nk_vc_printf("Mem[0x%016lx] = 0x%016lx\n",addr,data);
-	  break;
-      default:
-	  nk_vc_printf("Unknown size requested\n");
-	  break;
-      }
-      return 0;
-  }
-
-  if (((bwdq='b', sscanf(buf,"out b %lx %lx", &addr,&data))==2) ||
-      ((bwdq='w', sscanf(buf,"out w %lx %lx", &addr,&data))==2) ||
-      ((bwdq='d', sscanf(buf,"out d %lx %lx", &addr,&data))==2) ||
-      ((bwdq='q', sscanf(buf,"out %lx %lx", &addr, &data))==2)) {
-      addr &= 0xffff;
-      switch (bwdq) { 
-      case 'b': 
-	  data &= 0xff;
-	  outb((uint8_t) data, (uint16_t)addr);
-	  nk_vc_printf("IO[0x%04lx] = 0x%02lx\n",addr,data);
-	  break;
-      case 'w': 
-	  data &= 0xffff;
-	  outw((uint16_t) data, (uint16_t)addr);
-	  nk_vc_printf("IO[0x%04lx] = 0x%04lx\n",addr,data);
-	  break;
-      case 'd': 
-	  data &= 0xffffffff;
-	  outl((uint32_t) data, (uint16_t)addr);
-	  nk_vc_printf("IO[0x%04lx] = 0x%08lx\n",addr,data);
-	  break;
-      default:
-	  nk_vc_printf("Unknown size requested\n");
-	  break;
-      }
-      return 0;
-  }
-
-
-  if ((sscanf(buf,"rdmsr %x %lu", &msr, &size)==2) ||
-      (size=1, sscanf(buf,"rdmsr %x", &msr)==1)) {
-      uint64_t i,k;
-      for (i=0;i<size;i++) { 
-	  data = msr_read(msr+i);
-	  nk_vc_printf("MSR[0x%08x] = 0x%016lx ",(uint32_t)(msr+i),data);
-	  for (k=0;k<8;k++) { 
-	      nk_vc_printf("%02x",*(k + (uint8_t*)&data));
-	  }
-	  nk_vc_printf(" ");
-	  for (k=0;k<8;k++) { 
-	      nk_vc_printf("%c",isalnum(*(k + (uint8_t*)&data)) ?
-			   (*(k + (uint8_t*)&data)) : '.');
-	  }
-	  nk_vc_printf("\n");
-      }
-      return 0;
-  }
-
-  if (sscanf(buf, "wrmsr %x %lx",&msr,&data)==2) { 
-      msr_write(msr,data);
-      nk_vc_printf("MSR[0x%08x] = 0x%016lx\n",msr,data);
-      return 0;
-  }
-
-  if ((sub=0, sscanf(buf,"cpuid %x %lu", &id, &size)==2) ||
-      (size=1, sub=0, sscanf(buf,"cpuid %x",&id)==1) ||
-      (size=1, sub=1, sscanf(buf,"cpuidsub %x %x",&id,&idsub)==2)) {
-      uint64_t i,j,k;
-      cpuid_ret_t r;
-      uint32_t val[4];
-      
-      for (i=0;i<size;i++) {
-	  if (sub) { 
-	      cpuid_sub(id,idsub,&r);
-	      nk_vc_printf("CPUID[0x%08x, 0x%08x] =",(uint32_t)(id+i),idsub);
-	  } else {
-	      cpuid(id+i,&r);
-	      nk_vc_printf("CPUID[0x%08x] =",id+i);
-	  }
-	  val[0]=r.a; val[1]=r.b; val[2]=r.c; val[3]=r.d;
-	  for (j=0;j<4;j++) {
-	      nk_vc_printf(" ");
-	      for (k=0;k<4;k++) { 
-		  nk_vc_printf("%02x",*(k + (uint8_t*)&(val[j])));
-	      }
-	  }
-	  for (j=0;j<4;j++) {
-	      nk_vc_printf(" ");
-	      for (k=0;k<4;k++) { 
-		  nk_vc_printf("%c",isalnum(*(k + (uint8_t*)&(val[j]))) ?
-			       (*(k + (uint8_t*)&(val[j]))) : '.');
-	      }
-	  }
-	  nk_vc_printf("\n");
-      }
-      return 0;
-  }
-
-  if ((sscanf(buf,"mtrrs %d", &cpu)==1) ||
-      (cpu=-1, !strcmp(buf,"mtrrs"))) {
-      nk_mtrr_dump(cpu);
-      return 0;
-  }
-
-  if (sscanf(buf,"mt %lx", &addr)==1) {
-      uint8_t type;
-      char *typestr;
-	  
-      if (nk_mtrr_find_type((void*)addr,&type,&typestr)) {
-	  nk_vc_printf("Cannot find memory type for %p\n",(void*)addr);
-      } else {
-	  nk_vc_printf("Mem[0x%016lx] has type 0x%02x %s\n", addr, type, typestr);
-      }
-      return 0;
-  }
-  
-  if ((sscanf(buf,"int %d %d", &cpu, &intr)==2) ||
-      (cpu=my_cpu_id(), sscanf(buf,"int %d",&intr)==1)) {
-      if (cpu==my_cpu_id()) {
-	  apic_self_ipi(per_cpu_get(apic), intr);
-      } else if (cpu>=0) {
-	  apic_ipi(per_cpu_get(apic),cpu,intr);
-      } else {
-	  apic_bcast_ipi(per_cpu_get(apic),intr);
-	  apic_self_ipi(per_cpu_get(apic), intr);
-      }
-      return 0;
-  }
-
-  if (sscanf(buf,"burn a %s %llu %u %llu", name, &size_ns, &tpr, &priority)==4) { 
-    nk_vc_printf("Starting aperiodic burner %s with tpr %u, size %llu ms.and priority %llu\n", name, tpr, size_ns, priority);
-    size_ns *= 1000000;
-    launch_aperiodic_burner(name,size_ns,tpr,priority);
-    return 0;
-  }
-
-  if (sscanf(buf,"burn s %s %llu %u %llu %llu %llu %llu", name, &size_ns, &tpr, &phase, &size, &deadline, &priority)==7) { 
-    nk_vc_printf("Starting sporadic burner %s with size %llu ms tpr %u phase %llu from now size %llu ms deadline %llu ms from now and priority %lu\n",name,size_ns,tpr,phase,size,deadline,priority);
-    size_ns *= 1000000;
-    phase   *= 1000000; 
-    size    *= 1000000;
-    deadline*= 1000000; deadline+= nk_sched_get_realtime();
-    launch_sporadic_burner(name,size_ns,tpr,phase,size,deadline,priority);
-    return 0;
-  }
-
-  if (sscanf(buf,"burn p %s %llu %u %llu %llu %llu", name, &size_ns, &tpr, &phase, &period, &slice)==6) { 
-    nk_vc_printf("Starting periodic burner %s with size %llu ms tpr %u phase %llu from now period %llu ms slice %llu ms\n",name,size_ns,tpr,phase,period,slice);
-    size_ns *= 1000000;
-    phase   *= 1000000; 
-    period  *= 1000000;
-    slice   *= 1000000;
-    launch_periodic_burner(name,size_ns,tpr,phase,period,slice);
-    return 0;
-  }
-
-  if (sscanf(buf,"burnu p %s %llu %u %llu %llu %llu", name, &size_ns, &tpr, &phase, &period, &slice)==6) { 
-    nk_vc_printf("Starting periodic burner %s with size %llu ms tpr %u phase %llu from now period %llu us slice %llu us\n",name,size_ns,tpr,phase,period,slice);
-    size_ns *= 1000000;
-    phase   *= 1000; 
-    period  *= 1000;
-    slice   *= 1000;
-    launch_periodic_burner(name,size_ns,tpr,phase,period,slice);
-    return 0;
-  }
-
-#ifdef NAUT_CONFIG_PALACIOS_EMBED
-  if (sscanf(buf,"vm %s", name)==1) { 
-    extern int guest_start;
-    nk_vmm_start_vm(name,&guest_start,0xffffffff);
-    return 0;
-  }
-#endif
-
-  if (!strncasecmp(buf,"run",3)) {
-    handle_run(buf);
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"threads",7)) { 
-    if (sscanf(buf,"threads %d",&cpu)!=1) {
-      cpu=-1; 
-    }
-    nk_sched_dump_threads(cpu);
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"cores",5)) { 
-    if (sscanf(buf,"cores %d",&cpu)!=1) {
-      cpu=-1; 
-    }
-    nk_sched_dump_cores(cpu);
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"time",4)) { 
-    if (sscanf(buf,"time %d",&cpu)!=1) {
-      cpu=-1; 
-    }
-    nk_sched_dump_time(cpu);
-    return 0;
-  }
-
-  if (!strncasecmp(buf,"memi",4)) {
-      handle_meminfo(buf);
-      return 0;
-  }
-
-#ifdef NAUT_CONFIG_LOAD_LUA
-	if (!strncasecmp(buf, "lua", 3)) {
-		handle_lua_cmd(buf);
-		return 0;
-	}
-#endif
-
-  if (!strncasecmp(buf,"prog",4)) {
-      handle_prog_cmd(buf);
-      return 0;
-  }
-
-  nk_vc_printf("Don't understand \"%s\"\n",buf);
-  return 0;
-}
+#define INFO(fmt, args...)  INFO_PRINT("SHELL: " fmt, ##args)
+#define DEBUG(fmt, args...) DEBUG_PRINT("SHELL: " fmt, ##args)
+#define WARN(fmt, args...)  WARN_PRINT("SHELL: " fmt, ##args)
+#define ERROR(fmt, args...) ERROR_PRINT("SHELL: " fmt, ##args)
+
+#define CHAR_TO_IDX(k) (tolower(*(k)) - 'a')
+#define BAD_KEY(k) (*(k) == ' ')
 
 struct shell_op {
-  char name[32];
+  char name[SHELL_OP_NAME_LEN];
   char **script;
   uint32_t flags;
 };
 
-static void shell(void *in, void **out)
+struct shell_rtree_node {
+    struct shell_rtree_node * ents[RTREE_NUM_ENTRIES];
+    void * data;
+};
+
+struct shell_cmd {
+    struct shell_cmd_impl * impl;
+    unsigned ref_cnt;
+    void * priv_data;
+    struct list_head node;
+    struct shell_cmd_state * shell_state;
+};
+
+struct shell_cmd_state {
+    struct shell_rtree_node * root;
+    struct list_head cmd_list;
+};
+
+struct shell_rtree_iter {
+    struct shell_rtree_node * tree;
+    char * substr;
+};
+
+
+static struct shell_rtree_node *
+shell_rtree_init (void)
 {
-  struct shell_op *op = (struct shell_op *)in;
-  struct nk_virtual_console *vc = nk_create_vc(op->name,COOKED, 0x9f, 0, 0);
-  char buf[MAX_CMD];
-  char lastbuf[MAX_CMD];
-  int first=1;
+    struct shell_rtree_node * root = NULL;
 
-  if (!vc) { 
-    ERROR_PRINT("Cannot create virtual console for shell\n");
-    return;
-  }
-
-  if (nk_thread_name(get_cur_thread(),op->name)) {   
-    ERROR_PRINT("Cannot name shell's thread\n");
-    return;
-  }
-
-  if (nk_bind_vc(get_cur_thread(), vc)) { 
-    ERROR_PRINT("Cannot bind virtual console for shell\n");
-    return;
-  }
-   
-  nk_switch_to_vc(vc);
-  
-#define PROMPT 0xcf 
-#define INPUT  0x3f
-#define OUTPUT 0x9f
-
-  nk_vc_clear(OUTPUT);
-  nk_vc_setattr(OUTPUT);
-
-  if (op->script) {
-    int i;
-    for (i=0; *op->script[i]; i++) {
-      nk_vc_printf("***exec: %s\n",op->script[i]);
-      handle_cmd(op->script[i],MAX_CMD);
+    root = malloc(sizeof(*root));
+    if (!root) {
+        ERROR("Could not alloc shell radix tree\n");
+        return NULL;
     }
-    if (op->flags & NK_SHELL_SCRIPT_ONLY) {
-      goto out;
-    }
-  }
-  
-  while (1) {  
-    nk_vc_setattr(PROMPT);
-    nk_vc_printf("%s> ", (char*)in);
-    nk_vc_setattr(INPUT);
-    nk_vc_gets(buf,MAX_CMD,1);
-    nk_vc_setattr(OUTPUT);
+    memset(root, 0, sizeof(*root));
 
-    if (buf[0]==0 && !first) { 
-	// continue; // turn off autorepeat for now
-	if (handle_cmd(lastbuf,MAX_CMD)) { 
-	    break;
-	}
-    } else {
-	if (handle_cmd(buf,MAX_CMD)) {
-	    break;
-	}
-	memcpy(lastbuf,buf,MAX_CMD);
-	first=0;
-
-    }
-	       
-  }
-
-  nk_vc_printf("Exiting shell %s\n", (char*)in);
-
- out:
-  free(in);
-  nk_release_vc(get_cur_thread());
-
-  // exit thread
-  
+    return root;
 }
 
-nk_thread_id_t nk_launch_shell(char *name, int cpu, char **script, uint32_t flags)
-{
-  nk_thread_id_t tid;
-  struct shell_op *op = (struct shell_op *)malloc(sizeof(struct shell_op));
 
-  if (!op) {
+static void
+shell_rtree_deinit (struct shell_rtree_node * root)
+{
+    int i; 
+    for (i = 0; i < RTREE_NUM_ENTRIES; i++) {
+        if (root->ents[i]) {
+            shell_rtree_deinit(root->ents[i]);
+            free(root->ents[i]);
+        }
+    }
+}
+
+
+static void *
+shell_rtree_lookup (struct shell_rtree_node * node, char * key)
+{
+    uchar_t c = CHAR_TO_IDX(key);
+
+    if (BAD_KEY(key)) {
+        WARN("bad key (%s)\n", key);
+        return NULL;
+    }
+
+    if (!*key) {
+        return node->data;
+    }
+
+    if (node->ents[c]) {
+        return shell_rtree_lookup(node->ents[c], key + 1);
+    }
+
+    return NULL;
+}
+
+
+static int
+shell_rtree_insert (struct shell_rtree_node * node,
+                    char * key, 
+                    void * data)
+{
+    uchar_t c = CHAR_TO_IDX(key);
+
+    if (BAD_KEY(key)) {
+        WARN("Bad key (%s)\n", key);
+        return 0;
+    }
+
+    if (!*key) {
+        if (!node->data) {
+            node->data = data;
+            return 0;
+        } else {
+            WARN("Key already exists in cmd tree\n");
+            return 0;
+        }
+    } 
+
+    if (!node->ents[c]) {
+        node->ents[c] = malloc(sizeof(*node));
+        if (!node->ents[c]) {
+            ERROR("Could not alloc cmd node\n");
+            return -1;
+        }
+        memset(node->ents[c], 0, sizeof(*node));
+    } 
+
+    return shell_rtree_insert(node->ents[c], key + 1, data);
+}
+
+
+static void *
+shell_rtree_delete (char * key)
+{
+    ERROR("UNIMPLEMENTED (%s)\n", __func__);
+    return NULL;
+}
+
+
+static int
+shell_add_cmd (struct shell_cmd_state * state, struct shell_cmd * cmd)
+{
+    DEBUG("Adding cmd (%s) to shell command set\n", cmd->impl->cmd);
+    list_add(&(cmd->node), &(state->cmd_list));
+    return shell_rtree_insert(state->root, cmd->impl->cmd, (void*)cmd);
+}
+
+
+static int
+shell_handle_cmd (struct shell_cmd_state * state, char * buf, int max)
+{
+    struct shell_cmd * cmd = NULL;
+    int i = 0;
+    int j = 0;
+    char cmd_buf[SHELL_MAX_CMD];
+
+    memset(cmd_buf, 0, SHELL_MAX_CMD);
+
+    // skip whitespace at beginning of command
+    while ((buf[i] == ' ' || !buf[i]) && (i < max)) {
+        i++;
+    }
+    // only copy in non white-space
+    while (buf[i] != 0 && buf[i] != ' ' && (i < max)) {
+        cmd_buf[j++] = buf[i++];
+    }
+
+    cmd = shell_rtree_lookup(state->root, cmd_buf);
+
+    if (cmd && cmd->impl && cmd->impl->handler) {
+        return cmd->impl->handler(buf, cmd->priv_data);
+    }
+            
+    nk_vc_printf("Don't understand \"%s\"\n", cmd_buf);
+
     return 0;
-  }
-
-  memset(op,0,sizeof(*op));
-  
-  strncpy(op->name,name,32);
-  op->name[31]=0;
-  op->script = script;
-  op->flags = flags;
-  
-  if (nk_thread_start(shell, (void*)op, 0, 1, SHELL_STACK_SIZE, &tid, cpu)) { 
-      free(op);
-      return 0;
-  } else {
-      INFO_PRINT("Shell %s launched on cpu %d as %p\n",name,cpu,tid);
-      return tid;
-  }
 }
 
 
+static struct shell_cmd_state * 
+shell_cmd_init (void)
+{
+    extern struct shell_cmd_impl * __start_shell_cmds[];
+    extern struct shell_cmd_impl * __stop_shell_cmds[];
+    struct shell_cmd_impl ** tmp_cmd = __start_shell_cmds;
+    int i = 0;
 
+    struct shell_cmd_state * state = malloc(sizeof(*state));
+
+    if (!state) {
+        ERROR("Could not initialize shell cmd state\n");
+        return NULL;
+    }
+
+    state->root = shell_rtree_init();
+
+    INIT_LIST_HEAD(&state->cmd_list);
+
+    if (!state->root) {
+        ERROR("Could not initialize shell cmd tree\n");
+        return NULL;
+    }
+
+    while (tmp_cmd != __stop_shell_cmds) {
+
+        if (!(*tmp_cmd)) {
+            ERROR("Impossible shell cmd\n");
+            return NULL;
+        }
+
+        struct shell_cmd * c = malloc(sizeof(*c));
+        if (!c) {
+            ERROR("Could not allocate shell cmd\n");
+            return NULL;
+        }
+        memset(c, 0, sizeof(*c));
+        
+        c->ref_cnt     = 0;
+        c->impl        = *tmp_cmd;
+        c->priv_data   = c;
+        c->shell_state = state;
+
+        if (shell_add_cmd(state, c) != 0) {
+            ERROR("Could not register shell cmd (%s)\n", c->impl->cmd);
+            return NULL;
+        }
+
+        tmp_cmd = &(__start_shell_cmds[++i]);
+    }
+
+    return state;
+}
+
+
+static void
+shell_cmd_deinit (struct shell_cmd_state * state)
+{
+    shell_rtree_deinit(state->root);
+    free(state->root);
+    free(state);
+}
+
+
+static void 
+shell (void * in, void ** out)
+{
+    struct shell_op * op           = (struct shell_op *)in;
+    struct nk_virtual_console * vc = nk_create_vc(op->name, COOKED, 0x9f, 0, 0);
+    struct shell_cmd_state * state = NULL;
+    char buf[SHELL_MAX_CMD];
+    char lastbuf[SHELL_MAX_CMD];
+    int first = 1;
+
+    state = shell_cmd_init();
+
+    if (!state) {
+        ERROR("Could not initialize shell commands\n");
+        return;
+    }
+
+    if (!vc) { 
+        ERROR("Cannot create virtual console for shell\n");
+        return;
+    }
+
+    if (nk_thread_name(get_cur_thread(), op->name)) {   
+        ERROR("Cannot name shell's thread\n");
+        return;
+    }
+
+    if (nk_bind_vc(get_cur_thread(), vc)) { 
+        ERROR("Cannot bind virtual console for shell\n");
+        return;
+    }
+
+    nk_switch_to_vc(vc);
+    nk_vc_clear(OUTPUT_CHAR);
+    nk_vc_setattr(OUTPUT_CHAR);
+
+    if (op->script) {
+        int i;
+        for (i = 0; *op->script[i]; i++) {
+            nk_vc_printf("***exec: %s\n", op->script[i]);
+            shell_handle_cmd(state, op->script[i], SHELL_MAX_CMD);
+        }
+
+        if (op->flags & NK_SHELL_SCRIPT_ONLY) {
+            goto out;
+        }
+    }
+
+    while (1) {  
+
+        nk_vc_setattr(PROMPT_CHAR);
+        nk_vc_printf("%s> ", (char*)in);
+        nk_vc_setattr(INPUT_CHAR);
+        nk_vc_gets(buf, SHELL_MAX_CMD, 1);
+        nk_vc_setattr(OUTPUT_CHAR);
+
+        if (!buf[0] && !first) { 
+            // continue; // turn off autorepeat for now
+            if (shell_handle_cmd(state, lastbuf, SHELL_MAX_CMD)) { 
+                break;
+            }
+        } else {
+            if (shell_handle_cmd(state, buf, SHELL_MAX_CMD)) {
+                break;
+            }
+            memcpy(lastbuf, buf, SHELL_MAX_CMD);
+            first = 0;
+        }
+    }
+
+    nk_vc_printf("Exiting shell %s\n", (char*)in);
+
+out:
+    free(in);
+    nk_release_vc(get_cur_thread());
+}
+
+
+nk_thread_id_t 
+nk_launch_shell (char * name, 
+                 int cpu, 
+                 char ** script, 
+                 uint32_t flags)
+{
+    nk_thread_id_t tid;
+
+    struct shell_op * op = (struct shell_op *)malloc(sizeof(struct shell_op));
+
+    if (!op) {
+        WARN("No shell op provided, returning\n");
+        return 0;
+    }
+
+    memset(op, 0, sizeof(*op));
+
+    strncpy(op->name, name, SHELL_OP_NAME_LEN);
+
+    op->name[SHELL_OP_NAME_LEN-1] = 0;
+    op->script                    = script;
+    op->flags                     = flags;
+
+    if (nk_thread_start(shell, (void*)op, 0, 1, SHELL_STACK_SIZE, &tid, cpu)) { 
+        free(op);
+        return 0;
+    } else {
+        INFO_PRINT("Shell %s launched on cpu %d as %p\n",name,cpu,tid);
+        return tid;
+    }
+}
+
+
+static int
+handle_shell (char * buf, void * priv)
+{
+    char name[SHELL_MAX_CMD];
+
+    memset(name, 0, SHELL_MAX_CMD);
+
+    if (sscanf(buf, "shell %s", name) == 1) { 
+        nk_launch_shell(name, -1, 0, 0); // simple interactive shell
+        return 0;
+    }
+
+    nk_vc_printf("invalid shell command\n");
+
+    return 0;
+}
+
+
+static struct shell_cmd_impl shell_impl = {
+    .cmd      = "shell",
+    .help_str = "shell name",
+    .handler  = handle_shell,
+};
+nk_register_shell_cmd(shell_impl);
+
+
+static int
+handle_help (char * buf, void * priv)
+{
+    struct shell_cmd * my_cmd = (struct shell_cmd *)priv;
+    struct shell_cmd * cmd    = NULL;
+
+    nk_vc_printf("Available commands: \n\n");
+    list_for_each_entry(cmd, &(my_cmd->shell_state->cmd_list), node) {
+        if (cmd->impl && cmd->impl->help_str) {
+            nk_vc_printf("  %s\n", cmd->impl->help_str);
+        }
+    }
+    nk_vc_printf("\n");
+
+    return 0;
+}
+
+
+static struct shell_cmd_impl help_impl = {
+    .cmd      = "help",
+    .help_str = "help [cmd (or substring)]",
+    .handler  = handle_help,
+};
+nk_register_shell_cmd(help_impl);
+
+
+static int
+handle_exit (char * buf, void * priv)
+{
+    return 1;
+}
+
+static struct shell_cmd_impl exit_impl = {
+    .cmd      = "exit",
+    .help_str = "exit",
+    .handler  = handle_exit,
+};
+nk_register_shell_cmd(exit_impl);
+
+static int
+handle_vcs (char * buf, void * priv)
+{
+    nk_switch_to_vc_list();
+    return 0;
+}
+
+static struct shell_cmd_impl vcs_impl = {
+    .cmd      = "vcs",
+    .help_str = "vcs",
+    .handler  = handle_vcs,
+};
+nk_register_shell_cmd(vcs_impl);

--- a/src/nautilus/timer.c
+++ b/src/nautilus/timer.c
@@ -8,7 +8,7 @@
  * led by Sandia National Laboratories that includes several national 
  * laboratories and universities. You can find out more at:
  * http://www.v3vee.org  and
- * http://xtack.sandia.gov/hobbes
+ * http://xstack.sandia.gov/hobbes
  *
  * Copyright (c) 2015, Kyle C. Hale <kh@u.northwestern.edu>
  * Copyright (c) 2015, The V3VEE Project  <http://www.v3vee.org> 
@@ -29,6 +29,7 @@
 #include <nautilus/timer.h>
 #include <nautilus/scheduler.h>
 #include <nautilus/spinlock.h>
+#include <nautilus/shell.h>
 
 #include <stddef.h>
 
@@ -257,3 +258,51 @@ void nk_timer_deinit()
     INFO("Timers deinited\n");
     return;
 }
+
+
+static int
+handle_delay (char * buf, void * priv)
+{
+    uint64_t time_us;
+
+    if (sscanf(buf,"delay %lu", &time_us) == 1) {
+        nk_vc_printf("Delaying for %lu us\n", time_us);
+        nk_delay(time_us*1000UL);
+        return 0;
+    }
+
+    nk_vc_printf("invalid delay format\n");
+
+    return 0;
+}
+
+static int
+handle_sleep (char * buf, void * priv)
+{
+    uint64_t time_us;
+
+    if (sscanf(buf,"sleep %lu", &time_us) == 1) {
+        nk_vc_printf("Sleeping for %lu us\n", time_us);
+        nk_sleep(time_us*1000UL);
+        return 0;
+    }
+
+    nk_vc_printf("invalid sleep format\n");
+
+    return 0;
+}
+
+
+static struct shell_cmd_impl delay_impl = {
+    .cmd      = "delay",
+    .help_str = "delay us",
+    .handler  = handle_delay,
+};
+nk_register_shell_cmd(delay_impl);
+
+static struct shell_cmd_impl sleep_impl = {
+    .cmd      = "sleep",
+    .help_str = "sleep us",
+    .handler  = handle_sleep,
+};
+nk_register_shell_cmd(sleep_impl);

--- a/src/nautilus/vmm.c
+++ b/src/nautilus/vmm.c
@@ -23,6 +23,7 @@
 
 #include <nautilus/nautilus.h>
 #include <nautilus/vmm.h>
+#include <nautilus/shell.h>
 #include "palacios.h"
 
 struct v3_vm_info;
@@ -135,4 +136,26 @@ int nk_vmm_deinit()
   return palacios_vmm_exit();
 }
 
+
+static int
+handle_vm (char * buf, void * priv)
+{
+    if (sscanf(buf,"vm %s", name)==1) { 
+        extern int guest_start;
+        nk_vmm_start_vm(name, &guest_start, 0xffffffff);
+        return 0;
+    }
+
+    nk_vc_printf("Unknown VMM command\n");
+
+    return 0;
+}
+
+
+static struct shell_cmd_impl vm_impl = {
+    .cmd      = "vm",
+    .help_str = "vm name [embedded image]",
+    .handler  = handle_vm,
+};
+nk_register_shell_cmd(vm_impl);
   

--- a/src/net/Makefile
+++ b/src/net/Makefile
@@ -2,3 +2,5 @@ obj-$(NAUT_CONFIG_NET_ETHERNET) += ethernet/
 obj-$(NAUT_CONFIG_NET_COLLECTIVE) += collective/
 obj-$(NAUT_CONFIG_NET_LWIP) += lwip/
 
+obj-y += net.o
+

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -1,0 +1,286 @@
+/* 
+ * This file is part of the Nautilus AeroKernel developed
+ * by the Hobbes and V3VEE Projects with funding from the 
+ * United States National  Science Foundation and the Department of Energy.  
+ *
+ * The V3VEE Project is a joint project between Northwestern University
+ * and the University of New Mexico.  The Hobbes Project is a collaboration
+ * led by Sandia National Laboratories that includes several national 
+ * laboratories and universities. You can find out more at:
+ * http://www.v3vee.org  and
+ * http://xstack.sandia.gov/hobbes
+ *
+ * Copyright (c) 2018, Kyle Hale <khale@cs.iit.edu>
+ * Copyright (c) 2016, The V3VEE Project  <http://www.v3vee.org> 
+ *                     The Hobbes Project <http://xstack.sandia.gov/hobbes>
+ * All rights reserved.
+ *
+ * Authors: Kyle Hale <khale@cs.iit.edu>
+ *         
+ * This is free software.  You are permitted to use,
+ * redistribute, and modify it as specified in the file "LICENSE.txt".
+ */
+#include <nautilus/nautilus.h>
+#include <nautilus/shell.h>
+
+#ifdef NAUT_CONFIG_NET_ETHERNET
+#include <net/ethernet/ethernet_agent.h>
+#include <net/ethernet/ethernet_arp.h>
+#endif
+
+#ifdef NAUT_CONFIG_NET_LWIP
+#include <net/lwip/lwip.h>
+#endif
+
+static int 
+handle_net (char * buf, void * priv)
+{
+    char agentname[100], intname[100];
+    uint32_t type;
+    uint32_t ip[4];
+    uint32_t gw[4];
+    uint32_t netmask[4];
+    uint32_t dns[4];
+    int defaults=0;
+
+#ifdef NAUT_CONFIG_NET_ETHERNET
+    if (sscanf(buf,"net agent create %s %s",agentname, intname)==2) {
+        nk_vc_printf("Attempt to create ethernet agent %s for device %s\n",agentname, intname);
+        struct nk_net_dev *netdev = nk_net_dev_find(intname);
+        struct nk_net_ethernet_agent *agent;
+
+        if (!netdev) {
+            nk_vc_printf("Cannot find device %s\n",intname);
+            return 0;
+        }
+
+        agent = nk_net_ethernet_agent_create(netdev, agentname, 64, 64);
+
+        if (!agent) {
+            nk_vc_printf("Cannot create agent %s\n",agentname);
+            return 0;
+        }
+
+        nk_vc_printf("agent created\n");
+        return 0;
+    }
+
+
+    if (sscanf(buf,"net agent add %s %x",agentname, &type)==2) {
+        nk_vc_printf("Attempt to create interface for agent %s type %us\n", agentname,type);
+        struct nk_net_ethernet_agent *agent = nk_net_ethernet_agent_find(agentname);
+        struct nk_net_dev *netdev;
+        if (!agent) {
+            nk_vc_printf("Cannot find agent %s\n", agentname);
+            return 0;
+        }
+        netdev = nk_net_ethernet_agent_register_type(agent,type);
+        if (!netdev) {
+            nk_vc_printf("Failed to register for type\n");
+            return 0;
+        }
+        nk_vc_printf("New netdev is named: %s\n", netdev->dev.name);
+        return 0;
+    }
+
+    if (sscanf(buf,"net agent s%s %s",buf,agentname)==2) {
+        struct nk_net_ethernet_agent *agent = nk_net_ethernet_agent_find(agentname);
+        if (!agent) {
+            nk_vc_printf("Cannot find agent %s\n", agentname);
+            return 0;
+        }
+        if (buf[0]=='t' && buf[1]=='o') {
+            if (nk_net_ethernet_agent_stop(agent)) {
+                nk_vc_printf("Failed to to stop agent %s\n", agentname);
+            } else {
+                nk_vc_printf("Stopped agent %s\n", agentname);
+            }
+        } else if (buf[0]=='t' && buf[1]=='a') {
+            if (nk_net_ethernet_agent_start(agent)) {
+                nk_vc_printf("Failed to to start agent %s\n", agentname);
+            } else {
+                nk_vc_printf("Started agent %s\n", agentname);
+            }
+        } else {
+            nk_vc_printf("Unknown agent command\n");
+        }
+        return 0;
+    }
+
+
+
+    if (sscanf(buf,"net arp create %s %u.%u.%u.%u",agentname,&ip[0],&ip[1],&ip[2],&ip[3])==5) {
+        ipv4_addr_t ipv4 = ip[0]<<24 | ip[1]<<16 | ip[2]<<8 | ip[3];
+        struct nk_net_ethernet_agent *agent = nk_net_ethernet_agent_find(agentname);
+        if (!agent) {
+            nk_vc_printf("Cannot find agent %s\n", agentname);
+            return 0;
+        }
+        struct nk_net_dev *netdev = nk_net_ethernet_agent_get_underlying_device(agent);
+        struct nk_net_dev_characteristics c;
+        struct nk_net_ethernet_arper *arper = nk_net_ethernet_arper_create(agent);
+        if (!arper) {
+            nk_vc_printf("Failed to create arper\n");
+            return 0;
+        }
+
+        nk_net_dev_get_characteristics(netdev,&c);
+
+        if (nk_net_ethernet_arper_add(arper,ipv4,c.mac)) {
+            nk_vc_printf("Failed to add ip->mac mapping\n");
+            return 0;
+        }
+        nk_vc_printf("Added ip->mac mapping\n");
+        return 0;
+    }      
+
+    if (sscanf(buf,"net arp ask %u.%u.%u.%u",&ip[0],&ip[1],&ip[2],&ip[3])==4) {
+        ipv4_addr_t ipv4 = ip[0]<<24 | ip[1]<<16 | ip[2]<<8 | ip[3];
+        ethernet_mac_addr_t mac;
+        int rc = nk_net_ethernet_arp_lookup(0,ipv4,mac);
+        if (rc<0) {
+            nk_vc_printf("Lookup failed\n");
+        } else if (rc==0) {
+            nk_vc_printf("Lookup of %u.%u.%u.%u is %02x:%02x:%02x:%02x:%02x:%02x\n",
+                    ip[0],ip[1],ip[2],ip[3], mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
+        } else {
+            nk_vc_printf("Lookup is in progress\n");
+        }
+        return 0;
+    }
+
+#endif
+
+#ifdef NAUT_CONFIG_NET_LWIP
+    if (sscanf(buf,"net lwip start %s", intname)==1 && !strncasecmp(intname,"defaults",8)) {
+
+        struct nk_net_lwip_config conf = { .dns_ip = 0x08080808 } ;
+
+        if (nk_net_lwip_start(&conf)) {
+            nk_vc_printf("Failed to start lwip\n");
+            return 0;
+        }
+
+        struct nk_net_lwip_interface inter = { .name = "virtio-net0",
+            .ipaddr = 0x0a0a0a0a,
+            .netmask = 0xffffff00,
+            .gateway = 0x0a0a0a01 };
+
+
+        if (nk_net_lwip_add_interface(&inter)) {
+            nk_vc_printf("Failed to add interface\n");
+            return 0;
+        }
+
+        nk_vc_printf("LWIP started with defaults and default interface added\n");
+        return 0;
+    }
+
+    if (sscanf(buf,"net lwip start %u.%u.%u.%u", &dns[0], &dns[1], &dns[2], &dns[3])==4) {
+
+        struct nk_net_lwip_config conf = { .dns_ip = dns[0]<<24 | dns[1]<<16 | dns[2]<<8 | dns[3] } ;
+
+        if (nk_net_lwip_start(&conf)) {
+            nk_vc_printf("Failed to start lwip\n");
+            return 0;
+        }
+
+        nk_vc_printf("LWIP started\n");
+        return 0;
+
+    }
+
+
+    if (sscanf(buf,"net lwip add %s %u.%u.%u.%u %u.%u.%u.%u %u.%u.%u.%u\n",
+                &intname,
+                &ip[0], &ip[1], &ip[2], &ip[3],
+                &netmask[0], &netmask[1], &netmask[2], &netmask[3],
+                &gw[0], &gw[1], &gw[2], &gw[3])==13) {
+
+        struct nk_net_lwip_interface inter;
+
+        strncpy(inter.name,intname,DEV_NAME_LEN); inter.name[DEV_NAME_LEN-1]=0;
+        inter.ipaddr = ip[0]<<24 | ip[1]<<16 | ip[2]<<8 | ip[3];
+        inter.netmask = netmask[0]<<24 | netmask[1]<<16 | netmask[2]<<8 | netmask[3];
+        inter.gateway = gw[0]<<24 | gw[1]<<16 | gw[2]<<8 | gw[3];
+
+
+        if (nk_net_lwip_add_interface(&inter)) {
+            nk_vc_printf("Failed to add interface\n");
+            return 0;
+        }
+
+        nk_vc_printf("added interface %s ip=%u.%u.%u.%u netmask=%u.%u.%u.%u gw=%u.%u.%u.%u\n",
+                intname,ip[0],ip[1],ip[2],ip[3],netmask[0],netmask[1],netmask[2],netmask[3],
+                gw[0],gw[1],gw[2],gw[3]);
+
+        return 0;
+    }
+
+#ifdef NAUT_CONFIG_NET_LWIP_APP_ECHO
+    if (!strcasecmp(buf,"net lwip echo")) {
+        void echo_init();
+        nk_vc_printf("Starting echo server (port 7)\n");
+        echo_init();
+        return 0;
+    }
+#endif
+
+#ifdef NAUT_CONFIG_NET_LWIP_APP_HTTPD
+    if (!strcasecmp(buf,"net lwip httpd")) {
+        void httpd_init();
+        nk_vc_printf("Starting httpd (port 80)\n");
+        httpd_init();
+        return 0;
+    }
+#endif
+
+#ifdef NAUT_CONFIG_NET_LWIP_APP_LWIP_SHELL
+    if (!strcasecmp(buf,"net lwip shell")) {
+        void shell_init();
+        nk_vc_printf("Starting shell server (port 23)\n");
+        shell_init();
+        return 0;
+    }
+#endif
+
+#ifdef NAUT_CONFIG_NET_LWIP_APP_LWIP_SOCKET_ECHO
+    if (!strcasecmp(buf,"net lwip socket_echo")) {
+        void socket_echo_init();
+        nk_vc_printf("Starting socket_echo (port 7)\n");
+        socket_echo_init();
+        return 0;
+    }
+#endif
+
+#ifdef NAUT_CONFIG_NET_LWIP_APP_SOCKET_EXAMPLES
+    if (!strcasecmp(buf,"net lwip socket_examples")) {
+        void socket_examples_init();
+        nk_vc_printf("Starting socket_examples (outgoing)\n");
+        socket_examples_init();
+        return 0;
+    }
+#endif
+
+#ifdef NAUT_CONFIG_NET_LWIP_APP_LWIP_IPVCD
+    if (!strcasecmp(buf,"net lwip ipvcd")) {
+        void ipvcd_init();
+        nk_vc_printf("Starting Virtual Console Daemon (port 23)\n");
+        ipvcd_init();
+        return 0;
+    }
+#endif
+
+#endif
+
+    nk_vc_printf("No relevant network functionality is configured or bad command\n");
+
+    return 0;
+}
+
+static struct shell_cmd_impl net_impl = {
+    .cmd      = "net",
+    .help_str = "net ...",
+    .handler  = handle_net,
+};
+nk_register_shell_cmd(net_impl);

--- a/src/test/benchmark.c
+++ b/src/test/benchmark.c
@@ -8,7 +8,7 @@
  * led by Sandia National Laboratories that includes several national 
  * laboratories and universities. You can find out more at:
  * http://www.v3vee.org  and
- * http://xtack.sandia.gov/hobbes
+ * http://xstack.sandia.gov/hobbes
  *
  * Copyright (c) 2015, Kyle C. Hale <kh@u.northwestern.edu>
  * Copyright (c) 2015, The V3VEE Project  <http://www.v3vee.org> 
@@ -50,6 +50,7 @@
 #include <nautilus/numa.h>
 #include <nautilus/nemo.h>
 #include <nautilus/pmc.h>
+#include <nautilus/shell.h>
 
 #endif
 
@@ -1142,5 +1143,18 @@ int main () {
     return 0;
 }
 
+static int
+handle_bench (char * buf, void * priv)
+{
+    run_benchmarks();
+    return 0;
+}
+
+static struct shell_cmd_impl bench_impl = {
+    .cmd      = "bench",
+    .help_str = "bench",
+    .handler  = handle_bench,
+};
+nk_register_shell_cmd(bench_impl);
 
 #endif

--- a/src/test/groups.c
+++ b/src/test/groups.c
@@ -24,6 +24,7 @@
  */
 
 #include <nautilus/nautilus.h>
+#include <nautilus/shell.h>
 #include <nautilus/atomic.h>
 #include <nautilus/group.h>
 #include <nautilus/group_sched.h>
@@ -283,3 +284,16 @@ nk_thread_group_test() {
 
   return 0;
 }
+
+static int
+handle_groups (char * buf, void * priv)
+{
+    return nk_thread_group_test();
+}
+
+static struct shell_cmd_impl groups_impl = {
+    .cmd      = "grouptest",
+    .help_str = "grouptest",
+    .handler  = handle_groups,
+};
+nk_register_shell_cmd(groups_impl);

--- a/src/test/ndpc/test_ndpc.c
+++ b/src/test/ndpc/test_ndpc.c
@@ -1,3 +1,5 @@
+#include <nautilus/nautilus.h>
+#include <nautilus/shell.h>
 
 int ndpc_test_integral();
 int ndpc_test_fork();
@@ -23,3 +25,17 @@ int test_ndpc()
     
     return 0;
 }
+
+static int
+handle_ndpc (char * buf, void * priv)
+{
+    test_ndpc();
+    return 0;
+}
+
+static struct shell_cmd_impl ndpc_impl = {
+    .cmd      = "ndpc",
+    .help_str = "ndpc",
+    .handler  = handle_ndpc,
+};
+nk_register_shell_cmd(ndpc_impl);

--- a/src/test/nesl/test_nesl.c
+++ b/src/test/nesl/test_nesl.c
@@ -1,12 +1,27 @@
 #include <nautilus/nautilus.h>
+#include <nautilus/shell.h>
 #include <rt/nesl/nesl.h>
 
 
+int 
+test_nesl (void)
+{
+    nk_vc_printf("Running the built-in vcode block\n");
+    nk_nesl_exec(0);
+    nk_vc_printf("Done.\n");
+    return 0;
+}
 
- int test_nesl()
- {
-     nk_vc_printf("Running the built-in vcode block\n");
-     nk_nesl_exec(0);
-     nk_vc_printf("Done.\n");
-     return 0;
- }
+static int
+handle_nesl (char * buf, void * priv)
+{
+    test_nesl();
+    return 0;
+}
+
+static struct shell_cmd_impl nesl_impl = {
+    .cmd      = "nesl",
+    .help_str = "nesl",
+    .handler  = handle_nesl,
+};
+nk_register_shell_cmd(nesl_impl);

--- a/src/test/net_udp_echo.c
+++ b/src/test/net_udp_echo.c
@@ -32,6 +32,7 @@
 #include <nautilus/netdev.h>
 #include <nautilus/printk.h>
 #include <nautilus/mm.h>                      // malloc
+#include <nautilus/shell.h>
 #include <dev/pci.h>
 #include <nautilus/vc.h>                      // nk_vc_printf
 
@@ -781,3 +782,34 @@ static void nk_hostnamei() {
 }
 
 */
+
+static int
+handle_udp_echo (char * buf, void * priv)
+{
+    char nic[80];
+    char ip[80];
+    uint32_t port, num;
+
+    if (sscanf(buf,"udpecho %s %s %u %u", nic, ip, &port, &num) == 4) { 
+        nk_vc_printf("Testing udp echo server\n");
+        test_net_udp_echo(nic,ip,port,num);
+        return 0;
+    } 
+
+    if (sscanf(buf,"udpecho %s", nic) == 1) { 
+        nk_vc_printf("Testing udp echo server\n");
+        test_net_udp_echo(nic, "10.10.10.10", 5000, 20);
+        return 0;
+    }
+
+    nk_vc_printf("unknown udp_echo command\n");
+
+    return 0;
+}
+
+static struct shell_cmd_impl udp_impl = {
+    .cmd      = "udpecho",
+    .help_str = "udpecho nic [ip port num]",
+    .handler  = handle_udp_echo,
+};
+nk_register_shell_cmd(udp_impl);

--- a/src/test/omp/openmpbench_C_v31/main.c
+++ b/src/test/omp/openmpbench_C_v31/main.c
@@ -1,6 +1,8 @@
 // Converted from Edinburgh OpenMP benchmark main code
 // to run as kernel code
 
+#include <nautilus/nautilus.h>
+#include <nautilus/shell.h>
 #include <rt/omp/omp.h>
 
 int schedbench_main(int argc, char **argv);
@@ -37,4 +39,18 @@ int test_ompbench()
 
     return 0;
 }
+
+static int
+handle_ompb (char * buf, void * priv)
+{
+    test_ompbench();
+    return 0;
+}
+
+static struct shell_cmd_impl ompb_impl = {
+    .cmd      = "ompb",
+    .help_str = "ompb",
+    .handler  = handle_ompb,
+};
+nk_register_shell_cmd(ompb_impl);
 

--- a/src/test/omp/test_omp.c
+++ b/src/test/omp/test_omp.c
@@ -1,4 +1,5 @@
 #include <nautilus/nautilus.h>
+#include <nautilus/shell.h>
 #include <rt/omp/omp.h>
 
 #define N 4
@@ -42,7 +43,8 @@ static void report_num_threads(int level)
     }
 }
 
-static int omp_nested()
+static int 
+omp_nested (void)
 {
     omp_set_dynamic(0);
     #pragma omp parallel num_threads(2)
@@ -61,16 +63,34 @@ static int omp_nested()
 }
 
 
- int test_omp()
- {
-     nk_omp_thread_init();
-     nk_vc_printf("Starting simple test\n");
-     omp_simple();
-     //     goto out;
-     nk_vc_printf("Starting nested test\n");
-     omp_nested();
- out:
-     nk_vc_printf("OMP test finished\n");
-     nk_omp_thread_deinit();
-     return 0;
- }
+int 
+test_omp (void)
+{
+    nk_omp_thread_init();
+    nk_vc_printf("Starting simple test\n");
+    omp_simple();
+    //     goto out;
+    nk_vc_printf("Starting nested test\n");
+    omp_nested();
+//out:
+    nk_vc_printf("OMP test finished\n");
+    nk_omp_thread_deinit();
+    return 0;
+}
+
+
+static int
+handle_omp (char * buf, void * priv)
+{
+    test_omp();
+    return 0;
+}
+
+
+static struct shell_cmd_impl omp_impl = {
+    .cmd      = "omp",
+    .help_str = "omp",
+    .handler  = handle_omp,
+};
+nk_register_shell_cmd(omp_impl);
+

--- a/src/test/tasks.c
+++ b/src/test/tasks.c
@@ -22,6 +22,7 @@
  */
 
 #include <nautilus/nautilus.h>
+#include <nautilus/shell.h>
 #include <nautilus/task.h>
 #include <nautilus/scheduler.h>
 
@@ -188,3 +189,15 @@ int test_tasks()
 }
 
 
+static int
+handle_tasks (char * buf, void * priv)
+{
+    return test_tasks();
+}
+
+static struct shell_cmd_impl tasks_impl = {
+    .cmd      = "tasktest",
+    .help_str = "tasktest",
+    .handler  = handle_tasks,
+};
+nk_register_shell_cmd(tasks_impl);

--- a/src/test/threads.c
+++ b/src/test/threads.c
@@ -24,6 +24,7 @@
 #include <nautilus/nautilus.h>
 #include <nautilus/thread.h>
 #include <nautilus/scheduler.h>
+#include <nautilus/shell.h>
 #include <nautilus/vc.h>
 
 #define DO_PRINT       0
@@ -289,3 +290,16 @@ int test_threads()
 }
 
 
+static int
+handle_threads (char * buf, void * priv)
+{
+    test_threads();
+    return 0;
+}
+
+static struct shell_cmd_impl threads_impl = {
+    .cmd      = "threadtest",
+    .help_str = "threadtest",
+    .handler  = handle_threads,
+};
+nk_register_shell_cmd(threads_impl);


### PR DESCRIPTION
This PR introduces some major changes to the shell. The most significant change (in f31ebb777e3ac227feb014d614940ec427db6670) makes it so that shell commands no longer need to be added to `shell.c`. Rather, the handler and the registration can all be in the subsystem of interest. 

Some other bells and whistles added in this PR include:
- better help command with longest prefix matching. e.g. with the command:
    ```$> pci dev bus slot fun ```
the help command understands `$> help pci` and will print out the help string associated with that command. `$> help p` will print the help string for every available command that matches the string `p`.

- new `history` command, also with LPM. 
  * `$> history` <- prints out most recent history
  * `$> history 2` <- prints out the 2 most recent history items
  * `$> history pc` <- prints out all recent command invocations which match the string `pc`
- `fish`-style autocompletion at the shell. As you type at the shell, the shell will predict commands based on your history. You can hit `<TAB>` to accept the suggestion, followed by `<ENTER>` to run it.


