### PR TITLE
WLLVM support and Buddy Bug Fix

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -177,12 +177,24 @@ menu "Build"
           Chose whether to use GCC or CLang to build Nautilus
           Currently, GCC is by far the most tested option
 	  No guarantees that Clang will be able to build everything
+	  Clang/WLLVM will generate a bitcode file for the entire kernel
      config USE_GCC
        bool "GCC"
      config USE_CLANG
        bool "Clang/LLVM"
+     config USE_WLLVM
+       bool "Clang/WLLVM (generates top level bitcode file)" 
     endchoice
-
+    config USE_WLLVM_WHOLE_OPT
+       bool "Whole kernel optimization"
+       default false
+       depends on USE_WLLVM
+       help
+	   Re-optimizes entire kernel as a single unit
+           USAGE: 
+		make 
+		make whole_opt
+		make isoimage
     config COMPILER_PREFIX
        string "Prefix for compiler toolchain commands"
        default ""

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ NAME=Nautilus
 ISO_NAME:=nautilus.iso
 BIN_NAME:=nautilus.bin
 SYM_NAME:=nautilus.syms
-
+BC_NAME:=nautilus.bc
+LL_NAME:=nautilus.ll
 
 
 
@@ -314,6 +315,7 @@ CPPFLAGS        := $(NAUT_INCLUDE) -D__NAUTILUS__
 ifeq (,$(wildcard .config))
    NAUT_CONFIG_USE_GCC=1
    NAUT_CONFIG_USE_CLANG=0
+   NAUT_CONFIG_USE_WLLVM=0
    NAUT_CONFIG_COMPILER_PREFIX=
    NAUT_CONFIG_COMPILER_SUFFIX=
 else
@@ -332,6 +334,13 @@ ifdef NAUT_CONFIG_USE_CLANG
   LD		= $(CROSS_COMPILE)ld
   CC		= $(CROSS_COMPILE)$(COMPILER_PREFIX)clang$(COMPILER_SUFFIX)
   CXX           = $(CROSS_COMPILE)$(COMPILER_PREFIX)clang++$(COMPILER_SUFFIX)
+endif
+
+ifdef NAUT_CONFIG_USE_WLLVM
+  AS		= $(CROSS_COMPILE)$(COMPILER_PREFIX)llvm-as$(COMPILER_SUFFIX)
+  LD		= $(CROSS_COMPILE)ld
+  CC		= $(CROSS_COMPILE)$(COMPILER_PREFIX)wllvm$(COMPILER_SUFFIX)
+  CXX           = $(CROSS_COMPILE)$(COMPILER_PREFIX)wllvm++$(COMPILER_SUFFIX)
 endif
 
 ifdef NAUT_CONFIG_USE_GCC
@@ -361,6 +370,11 @@ ifdef NAUT_CONFIG_USE_GCC
 endif
 
 ifdef NAUT_CONFIG_USE_CLANG
+  COMMON_FLAGS += -O2  # -fno-delete-null-pointer-checks
+   # -O3 will also work - PAD
+endif
+
+ifdef NAUT_CONFIG_USE_WLLVM
   COMMON_FLAGS += -O2  # -fno-delete-null-pointer-checks
    # -O3 will also work - PAD
 endif
@@ -421,11 +435,10 @@ AFLAGS		:=
 export	VERSION PATCHLEVEL SUBLEVEL KERNELRELEASE KERNELVERSION \
 	ARCH CONFIG_SHELL HOSTCC HOSTCFLAGS CROSS_COMPILE AS LD CC CXX\
 	CPP AR NM STRIP OBJCOPY OBJDUMP MAKE AWK GENKSYMS PERL UTS_MACHINE \
-	HOSTCXX HOSTCXXFLAGS CHECK
-
-export CPPFLAGS NOSTDINC_FLAGS NAUT_INCLUDE OBJCOPYFLAGS LDFLAGS
-export CFLAGS CXXFLAGS CFLAGS_KERNEL 
-export AFLAGS AFLAGS_KERNEL
+	HOSTCXX HOSTCXXFLAGS CHECK \
+export CPPFLAGS NOSTDINC_FLAGS NAUT_INCLUDE OBJCOPYFLAGS LDFLAGS \
+export CFLAGS CXXFLAGS CFLAGS_KERNEL \
+export AFLAGS AFLAGS_KERNEL \
 
 # When compiling out-of-tree modules, put MODVERDIR in the module
 # tree rather than in the kernel tree. The kernel tree might
@@ -703,7 +716,7 @@ quiet_cmd_nautilus_version = GEN     .version
 	if [ ! -r .version ]; then			\
 	  rm -f .version;				\
 	  echo 1 >.version;				\
-	else						\
+        else						\
 	  mv .version .old_version;			\
 	  expr 0$$(cat .old_version) + 1 >.version;	\
 	fi;					
@@ -773,6 +786,21 @@ endif
 nautilus.asm: $(BIN_NAME)
 	$(OBJDUMP) --disassemble $< > $@
 
+ifdef NAUT_CONFIG_USE_WLLVM
+bitcode: $(BIN_NAME)
+	extract-bc $(BIN_NAME) -o $(BC_NAME)
+	llvm-dis $(BC_NAME) -o $(LL_NAME)
+
+ifdef NAUT_CONFIG_USE_WLLVM_WHOLE_OPT
+whole_opt: $(BIN_NAME)  
+	extract-bc $(BIN_NAME) -o $(BC_NAME)
+	opt -strip-debug $(BC_NAME)
+	clang $(CFLAGS) -c $(BC_NAME) -o .nautilus.o
+	$(LD) $(LDFLAGS) $(LDFLAGS_vmlinux) -o $(BIN_NAME) -T $(LD_SCRIPT) .nautilus.o `scripts/findasm.pl`
+	rm .nautilus.o
+endif
+
+endif
 # The actual objects are generated when descending, 
 # make sure no implicit rule kicks in
 $(sort  $(nautilus)) : $(nautilus-dirs) ;

--- a/configs/testing/default.config
+++ b/configs/testing/default.config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 #Nautilus: 
-# Sun Sep  1 18:18:50 2019
+# Thu Sep  5 15:44:40 2019
 #
 
 #
@@ -23,6 +23,7 @@ NAUT_CONFIG_CXX_SUPPORT=y
 # NAUT_CONFIG_RUST_SUPPORT is not set
 NAUT_CONFIG_USE_GCC=y
 # NAUT_CONFIG_USE_CLANG is not set
+# NAUT_CONFIG_USE_WLLVM is not set
 NAUT_CONFIG_COMPILER_PREFIX=""
 NAUT_CONFIG_COMPILER_SUFFIX=""
 NAUT_CONFIG_TOOLCHAIN_ROOT=""

--- a/configs/testing/full-debug.config
+++ b/configs/testing/full-debug.config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 #Nautilus: 
-# Sun Sep  1 18:20:48 2019
+# Thu Sep  5 15:45:12 2019
 #
 
 #
@@ -23,6 +23,7 @@ NAUT_CONFIG_CXX_SUPPORT=y
 # NAUT_CONFIG_RUST_SUPPORT is not set
 NAUT_CONFIG_USE_GCC=y
 # NAUT_CONFIG_USE_CLANG is not set
+# NAUT_CONFIG_USE_WLLVM is not set
 NAUT_CONFIG_COMPILER_PREFIX=""
 NAUT_CONFIG_COMPILER_SUFFIX=""
 NAUT_CONFIG_TOOLCHAIN_ROOT=""

--- a/scripts/findasm.pl
+++ b/scripts/findasm.pl
@@ -1,0 +1,9 @@
+#!/usr/bin/perl -w
+
+@files=`find . -name "*.S"`;
+chomp(@files);
+foreach $f (@files) {
+	$o = $f;
+	$o =~ s/\.S$/\.o/;
+	print " $o " if (-e $o);
+}

--- a/src/nautilus/mm/buddy.c
+++ b/src/nautilus/mm/buddy.c
@@ -349,7 +349,10 @@ buddy_free(
 {
     ASSERT(mp);
     ASSERT(order <= mp->pool_order);
-    ASSERT(!((uint64_t)addr % (1ULL<<order)));  // aligned to own size only
+    ASSERT(// cannot be aligned to own size if pool start is not multiple of alignment
+	   (mp->base_addr && (order > __builtin_ctzl(mp->base_addr)))
+	   // otherwise must be aligned to own size
+	   || !((uint64_t)addr % (1ULL<<order)));
 
     BUDDY_DEBUG("BUDDY FREE on memory pool: %p addr=%p base=%p order=%lu\n",mp,addr,mp->base_addr, order);
 


### PR DESCRIPTION
This enhancement adds the ability to optionally build with the WLLVM tool.   The result of doing this is a nautilus.bin with an embedded copy of *all* bitcode.    If you do "make bitcode" it will give you this as a separate file.

This also adds a new target that builds on this support for optimization.   If you do "make whole_opt", a second compilation pass will happen that will collectively optimize everything, producing a new nautilus.bin. 

These enhancements are invisible unless the user enables them in the configuration. 

Also included here is a bug fix for the buddy allocator (an incorrect assertion).  This avoids an incorrect panic when assertions are enabled, and a free happens for a block whose size is larger than the maximum possible alignment the pool can support.   For example, if the memory pool starts at 0x100000 (1 MB), then it cannot provide alignment >1MB.  If asked to allocate 2MB (a thread stack, say), it will return a 2 MB block aligned to 1 MB.    When we free this block, it is *not* an error that it is not aligned to 2 MB.   