### PR TITLE
Bug fix: Correctly set up floating point state on thread creation

### DIFF
--- a/src/nautilus/thread.c
+++ b/src/nautilus/thread.c
@@ -473,6 +473,12 @@ int nk_thread_run(nk_thread_id_t t)
 
   THREAD_DEBUG("Run thread initialized: %p (tid=%lu) stack=%p size=%lu rsp=%p\n",newthread,newthread->tid,newthread->stack,newthread->stack_size,newthread->rsp);
 
+#ifdef NAUT_CONFIG_FPU_SAVE
+    // clone the floating point state
+    extern void nk_fp_save(void *dest);
+    nk_fp_save(newthread->fpu_state);
+#endif
+
   if (nk_sched_make_runnable(newthread, newthread->current_cpu,1)) { 
       THREAD_ERROR("Scheduler failed to run thread (%p, tid=%u) on cpu %u\n",
 		  newthread, newthread->tid, newthread->current_cpu);


### PR DESCRIPTION
Minor bug fix - but need to assure that new threads do no have zeroed mxcsr.   This clones the mxcsr and other state of the creating thread into the new thread.   Already done for thread_fork, but somehow this got lost for thread_create