### PR TITLE
update HRT linker script/shutdown code to compile

### DIFF
--- a/link/hrt.lds
+++ b/link/hrt.lds
@@ -1,9 +1,7 @@
 ENTRY(nautilus_entry)
-
 SECTIONS
 {
-    . = 0x10000000 + HIHALF_OFFSET;
-
+    . = 0x10000000 + 0xffff800000000000;
     .boot :
     {
         *(.mbhdr)
@@ -15,60 +13,65 @@ SECTIONS
         pdpt = .;
         . += 0x1000;
         pd = .;
-        . += 0x1000; 
-
+        . += 0x1000;
         boot_stack_start = .;
-        . += 0x200000;  /* we start out with a 2MB stack */
+        . += 0x200000;
         boot_stack_end = .;
     }
-
-
-    .text ALIGN(0x1000) : 
+    .text ALIGN(0x1000) :
     {
         *(.text*)
         *(.gnu.linkonce.t*)
     }
-
     .init ALIGN(0x1000) : AT(ADDR(.text) + SIZEOF(.text))
     {
         *(.init)
         *(.gnu.linkonce.init)
     }
-
     .fini ALIGN(0x1000) : AT(ADDR(.init) + SIZEOF(.init))
     {
         *(.fini)
         *(.gnu.linkonce.fini)
     }
-
     .init_array ALIGN(0x1000) : AT(ADDR(.fini) + SIZEOF(.fini))
     {
         _init_array_start = .;
         *(.init_array*)
         _init_array_end = .;
         *(.gnu.linkonce.init_array*)
-
     }
-
 
     .gcc_except_table ALIGN(0x1000) : AT(ADDR(.init_array) + SIZEOF(.init_array))
     {
         *(.gcc_except_table*)
         *(.gnu.linkonce.gcc_except*)
     }
-    
+
     .data ALIGN(0x1000) : AT(ADDR(.gcc_except_table) + SIZEOF(.gcc_except_table))
     {
         *(.data*)
         *(.gnu.linkonce.d*)
     }
-    
-    .rodata ALIGN(0x1000) : AT(ADDR(.data) + SIZEOF(.data))
+
+    .tests ALIGN(0x1000) : AT(ADDR(.data) + SIZEOF(.data))
+    {
+        __start_tests = .;
+        *(.tests*);
+        __stop_tests = .;
+    }
+
+    .cmdline_flags ALIGN(0x1000) : AT(ADDR(.tests) + SIZEOF(.tests))
+    {
+        __start_flags = .;
+        *(.cmdline_flags*);
+        __stop_flags = .;
+    }
+
+    .rodata ALIGN(0x1000) : AT(ADDR(.cmdline_flags) + SIZEOF(.cmdline_flags))
     {
         *(.rodata*)
         *(.gnu.linkonce.r*)
     }
-    
 
     .got ALIGN(0x1000) : AT(ADDR(.rodata)+SIZEOF(.rodata))
     {
@@ -76,22 +79,26 @@ SECTIONS
         *(.gnu.linkconce.got*)
     }
 
+    .shell_cmds ALIGN(0x1000) : AT(ADDR(.got)+SIZEOF(.got))
+    {
+        __start_shell_cmds = .;
+        *(.shell_cmds*);
+        __stop_shell_cmds = .;
+    }
 
-    _loadEnd = .; 
-    
-    .bss ALIGN(0x1000) : AT(ADDR(.got)+SIZEOF(.got))
+    _loadEnd = .;
+
+
+    .bss ALIGN(0x1000) : AT(ADDR(.shell_cmds)+SIZEOF(.shell_cmds))
     {
         *(COMMON)
         *(.bss*)
         *(.gnu.linkonce.b*)
     }
-    
-    _bssEnd = .; 
-    
+    _bssEnd = .;
     /DISCARD/ :
     {
         *(.comment)
         *(.eh_frame)
     }
 }
-

--- a/link/nautilus.ld
+++ b/link/nautilus.ld
@@ -100,7 +100,7 @@ SECTIONS
 
     _loadEnd = .; 
     
-    .bss ALIGN(0x1000) : AT(ADDR(.got)+SIZEOF(.got))
+    .bss ALIGN(0x1000) : AT(ADDR(.shell_cmds)+SIZEOF(.shell_cmds))
     {
         *(COMMON)
         *(.bss*)

--- a/link/nautilus.ld.hrt
+++ b/link/nautilus.ld.hrt
@@ -45,15 +45,24 @@ SECTIONS
         *(.gcc_except_table*)
         *(.gnu.linkonce.gcc_except*)
     }
-
-    _data_start = .;
-
     .data ALIGN(0x1000) : AT(ADDR(.gcc_except_table) + SIZEOF(.gcc_except_table))
     {
         *(.data*)
         *(.gnu.linkonce.d*)
     }
-    .rodata ALIGN(0x1000) : AT(ADDR(.data) + SIZEOF(.data))
+    .tests ALIGN(0x1000) : AT(ADDR(.data) + SIZEOF(.data))
+    {
+        __start_tests = .;
+        *(.tests*);
+        __stop_tests = .;
+    }
+    .cmdline_flags ALIGN(0x1000) : AT(ADDR(.tests) + SIZEOF(.tests))
+    {
+        __start_flags = .;
+        *(.cmdline_flags*);
+        __stop_flags = .;
+    }
+    .rodata ALIGN(0x1000) : AT(ADDR(.cmdline_flags) + SIZEOF(.cmdline_flags))
     {
         *(.rodata*)
         *(.gnu.linkonce.r*)
@@ -63,17 +72,20 @@ SECTIONS
         *(.got*)
         *(.gnu.linkconce.got*)
     }
+    .shell_cmds ALIGN(0x1000) : AT(ADDR(.got)+SIZEOF(.got))
+    {
+        __start_shell_cmds = .;
+        *(.shell_cmds*);
+        __stop_shell_cmds = .;
+    }
     _loadEnd = .;
-    .bss ALIGN(0x1000) : AT(ADDR(.got)+SIZEOF(.got))
+    .bss ALIGN(0x1000) : AT(ADDR(.shell_cmds)+SIZEOF(.shell_cmds))
     {
         *(COMMON)
         *(.bss*)
         *(.gnu.linkonce.b*)
     }
     _bssEnd = .;
-
-    _data_end = .;
-
     /DISCARD/ :
     {
         *(.comment)

--- a/src/arch/hrt/shutdown.c
+++ b/src/arch/hrt/shutdown.c
@@ -150,6 +150,39 @@ get_s5 (struct shutdown_info * s)
     return 0;
 }
 
+/* 
+ * NOTE: this requires that QEMU was passed the flag
+ * -device isa-debug-exit 
+ */
+static inline void  __attribute__((noreturn))
+qemu_isa_debug_exit (uint16_t code)
+{
+    outb(code, 0x501);
+
+    while (1) halt();
+}
+
+
+/*
+ * QEMU's ISA debug device can be used to
+ * shut it down. You must run QEMU with the
+ * -device isa-debug-exit flag. It will take
+ *  the value written to the port and use it
+ *  to derive the exit code that QEMU produces:
+ *     exit( (val << 1) | 1);
+ */
+void
+qemu_shutdown (void)
+{
+    qemu_isa_debug_exit(0x32);
+}
+
+void
+qemu_shutdown_with_code (uint16_t code)
+{
+    qemu_isa_debug_exit(code);
+}
+
         
 
 /* TODO: fix this */


### PR DESCRIPTION
This commit brings the HRT-specific linker script in line with recent changes due to the command-line, shell, and testing frameworks. Also addition of shutdown code relied on by the testing framework. 