### PR TITLE
Better API for topology information

### DIFF
--- a/include/nautilus/cpu.h
+++ b/include/nautilus/cpu.h
@@ -33,6 +33,35 @@ ulong_t nk_detect_cpu_freq(uint32_t);
 uint8_t nk_is_amd(void);
 uint8_t nk_is_intel(void);
 
+/******* Convenience API for CPU topology ************/
+
+typedef enum {
+	NK_ALL_FILT,       // all sibling threads/cpus 
+    NK_HW_THREAD_FILT, // thread on same hw thread (hyperthread)
+    NK_PHYS_CORE_FILT, // threads/CPUs on same physical core
+    NK_SOCKET_FILT,    // threads/CPUs on same socket
+} nk_topo_filt_t;
+
+struct cpu;
+
+uint32_t nk_get_smt_id (struct cpu * cpu); // get a core's hyperthread ID (within physical core)
+uint32_t nk_get_my_smt_id (void);
+uint32_t nk_get_socket_id (struct cpu * cpu); // get this CPU's socket ID
+uint32_t nk_get_my_socket_id (void);
+uint32_t nk_get_phys_core_id (struct cpu * cpu); // get this CPU's *physical* core ID
+uint32_t nk_get_my_phys_core_id (void);
+uint8_t  nk_cpus_share_phys_core (struct cpu * a, struct cpu * b); // do these two CPU's share a physical core? (distinct hyperthreads)
+uint8_t  nk_same_phys_core_as_me (struct cpu * other);
+uint8_t  nk_cpus_share_socket (struct cpu * a, struct cpu * b); // do these two CPU's share a socket?
+uint8_t  nk_same_socket_as_me (struct cpu * other);
+
+void nk_map_sibling_cpus (void (func)(struct cpu * cpu, void * state), nk_topo_filt_t filter, void * state);
+void nk_map_core_sibling_cpus (void (func)(struct cpu * cpu, void * state), void * state);
+void nk_map_socket_sibling_cpus (void (func)(struct cpu * cpu, void * state), void * state);
+
+/************** End CPU topology API **********************/
+
+
 #define RFLAGS_CF   (1 << 0)
 #define RFLAGS_PF   (1 << 2)
 #define RFLAGS_AF   (1 << 4)

--- a/include/nautilus/cpu.h
+++ b/include/nautilus/cpu.h
@@ -8,14 +8,14 @@
  * led by Sandia National Laboratories that includes several national 
  * laboratories and universities. You can find out more at:
  * http://www.v3vee.org  and
- * http://xtack.sandia.gov/hobbes
+ * http://xstack.sandia.gov/hobbes
  *
- * Copyright (c) 2015, Kyle C. Hale <kh@u.northwestern.edu>
+ * Copyright (c) 2015, Kyle C. Hale <khale@cs.iit.edu>
  * Copyright (c) 2015, The V3VEE Project  <http://www.v3vee.org> 
  *                     The Hobbes Project <http://xstack.sandia.gov/hobbes>
  * All rights reserved.
  *
- * Author: Kyle C. Hale <kh@u.northwestern.edu>
+ * Author: Kyle C. Hale <khale@cs.iit.edu>
  *
  * This is free software.  You are permitted to use,
  * redistribute, and modify it as specified in the file "LICENSE.txt".
@@ -32,34 +32,6 @@ extern "C" {
 ulong_t nk_detect_cpu_freq(uint32_t);
 uint8_t nk_is_amd(void);
 uint8_t nk_is_intel(void);
-
-/******* Convenience API for CPU topology ************/
-
-typedef enum {
-	NK_ALL_FILT,       // all sibling threads/cpus 
-    NK_HW_THREAD_FILT, // thread on same hw thread (hyperthread)
-    NK_PHYS_CORE_FILT, // threads/CPUs on same physical core
-    NK_SOCKET_FILT,    // threads/CPUs on same socket
-} nk_topo_filt_t;
-
-struct cpu;
-
-uint32_t nk_get_smt_id (struct cpu * cpu); // get a core's hyperthread ID (within physical core)
-uint32_t nk_get_my_smt_id (void);
-uint32_t nk_get_socket_id (struct cpu * cpu); // get this CPU's socket ID
-uint32_t nk_get_my_socket_id (void);
-uint32_t nk_get_phys_core_id (struct cpu * cpu); // get this CPU's *physical* core ID
-uint32_t nk_get_my_phys_core_id (void);
-uint8_t  nk_cpus_share_phys_core (struct cpu * a, struct cpu * b); // do these two CPU's share a physical core? (distinct hyperthreads)
-uint8_t  nk_same_phys_core_as_me (struct cpu * other);
-uint8_t  nk_cpus_share_socket (struct cpu * a, struct cpu * b); // do these two CPU's share a socket?
-uint8_t  nk_same_socket_as_me (struct cpu * other);
-
-void nk_map_sibling_cpus (void (func)(struct cpu * cpu, void * state), nk_topo_filt_t filter, void * state);
-void nk_map_core_sibling_cpus (void (func)(struct cpu * cpu, void * state), void * state);
-void nk_map_socket_sibling_cpus (void (func)(struct cpu * cpu, void * state), void * state);
-
-/************** End CPU topology API **********************/
 
 
 #define RFLAGS_CF   (1 << 0)

--- a/include/nautilus/numa.h
+++ b/include/nautilus/numa.h
@@ -92,8 +92,19 @@ struct mem_region * nk_get_base_region_by_num (unsigned num);
 
 
 struct nk_topo_params {
-    uint32_t smt_bits;
-    uint32_t core_bits;
+
+    // amd
+    uint32_t max_ncores;
+    uint32_t max_nthreads;
+
+    // intel
+	uint32_t core_plus_mask_width;
+	uint32_t core_only_select_mask;
+	uint32_t core_plus_select_mask;
+    uint32_t smt_mask_width;
+    uint32_t smt_select_mask;
+    uint32_t pkg_select_mask_width;
+    uint32_t pkg_select_mask;
 };
 
 struct nk_cpu_coords {

--- a/include/nautilus/scheduler.h
+++ b/include/nautilus/scheduler.h
@@ -192,6 +192,18 @@ void nk_sched_dump_time(int cpu);
 // cpu==-means all cpus
 void nk_sched_map_threads(int cpu, void (func)(struct nk_thread *t, void *state), void *state);
 
+uint8_t nk_threads_share_hwthread (struct nk_thread * a, struct nk_thread * b);
+uint8_t nk_thread_shares_hwthread_with_me (struct nk_thread * other);
+uint8_t nk_threads_share_core (struct nk_thread * a, struct nk_thread * b);
+uint8_t nk_thread_shares_core_with_me (struct nk_thread * other);
+uint8_t nk_threads_share_socket (struct nk_thread * a, struct nk_thread * b);
+uint8_t nk_thread_shares_socket_with_me (struct nk_thread * other);
+
+void nk_sched_map_sibling_threads(void (func)(struct nk_thread *t, void *state), nk_topo_filt_t filter, void *state);
+void nk_sched_map_hwthread_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state);
+void nk_sched_map_core_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state);
+void nk_sched_map_socket_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state);
+
 
 // Provide ability to stop and start the world from the caller
 // This forces all cores, except the caller out into an interrupt

--- a/include/nautilus/scheduler.h
+++ b/include/nautilus/scheduler.h
@@ -192,18 +192,6 @@ void nk_sched_dump_time(int cpu);
 // cpu==-means all cpus
 void nk_sched_map_threads(int cpu, void (func)(struct nk_thread *t, void *state), void *state);
 
-uint8_t nk_threads_share_hwthread (struct nk_thread * a, struct nk_thread * b);
-uint8_t nk_thread_shares_hwthread_with_me (struct nk_thread * other);
-uint8_t nk_threads_share_core (struct nk_thread * a, struct nk_thread * b);
-uint8_t nk_thread_shares_core_with_me (struct nk_thread * other);
-uint8_t nk_threads_share_socket (struct nk_thread * a, struct nk_thread * b);
-uint8_t nk_thread_shares_socket_with_me (struct nk_thread * other);
-
-void nk_sched_map_sibling_threads(void (func)(struct nk_thread *t, void *state), nk_topo_filt_t filter, void *state);
-void nk_sched_map_hwthread_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state);
-void nk_sched_map_core_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state);
-void nk_sched_map_socket_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state);
-
 
 // Provide ability to stop and start the world from the caller
 // This forces all cores, except the caller out into an interrupt

--- a/include/nautilus/topo.h
+++ b/include/nautilus/topo.h
@@ -1,0 +1,70 @@
+/* 
+ * This file is part of the Nautilus AeroKernel developed
+ * by the Hobbes and V3VEE Projects with funding from the 
+ * United States National  Science Foundation and the Department of Energy.  
+ *
+ * The V3VEE Project is a joint project between Northwestern University
+ * and the University of New Mexico.  The Hobbes Project is a collaboration
+ * led by Sandia National Laboratories that includes several national 
+ * laboratories and universities. You can find out more at:
+ * http://www.v3vee.org  and
+ * http://xstack.sandia.gov/hobbes
+ *
+ * Copyright (c) 2020, Kyle C. Hale <khale@cs.iit.edu>
+ * Copyright (c) 2020, The V3VEE Project  <http://www.v3vee.org> 
+ *                     The Hobbes Project <http://xstack.sandia.gov/hobbes>
+ * All rights reserved.
+ *
+ * Author: Kyle C. Hale <khale@cs.iit.edu>
+ *
+ * This is free software.  You are permitted to use,
+ * redistribute, and modify it as specified in the file "LICENSE.txt".
+ */
+#ifndef __TOPO_H__
+#define __TOPO_H__
+
+typedef enum {
+	NK_ALL_FILT,       // all sibling threads/cpus 
+    NK_HW_THREAD_FILT, // thread on same hw thread (hyperthread)
+    NK_PHYS_CORE_FILT, // threads/CPUs on same physical core
+    NK_SOCKET_FILT,    // threads/CPUs on same socket
+} nk_topo_filt_t;
+
+/******* Convenience API for CPU topology ************/
+struct cpu;
+
+uint32_t nk_topo_get_smt_id (struct cpu * cpu); // get a core's hyperthread ID (within physical core)
+uint32_t nk_topo_get_my_smt_id (void);
+uint32_t nk_topo_get_socket_id (struct cpu * cpu); // get this CPU's socket ID
+uint32_t nk_topo_get_my_socket_id (void);
+uint32_t nk_topo_get_phys_core_id (struct cpu * cpu); // get this CPU's *physical* core ID
+uint32_t nk_topo_get_my_phys_core_id (void);
+uint8_t  nk_topo_cpus_share_phys_core (struct cpu * a, struct cpu * b); // do these two CPU's share a physical core? (distinct hyperthreads)
+uint8_t  nk_topo_same_phys_core_as_me (struct cpu * other);
+uint8_t  nk_topo_cpus_share_socket (struct cpu * a, struct cpu * b); // do these two CPU's share a socket?
+uint8_t  nk_topo_same_socket_as_me (struct cpu * other);
+
+void nk_topo_map_sibling_cpus (void (func)(struct cpu * cpu, void * state), nk_topo_filt_t filter, void * state);
+void nk_topo_map_core_sibling_cpus (void (func)(struct cpu * cpu, void * state), void * state);
+void nk_topo_map_socket_sibling_cpus (void (func)(struct cpu * cpu, void * state), void * state);
+
+/************** End CPU topology API *****************/
+
+
+/******* Convenience API for thread topology ************/
+struct nk_thread;
+
+uint8_t nk_topo_threads_share_hwthread (struct nk_thread * a, struct nk_thread * b);
+uint8_t nk_topo_thread_shares_hwthread_with_me (struct nk_thread * other);
+uint8_t nk_topo_threads_share_core (struct nk_thread * a, struct nk_thread * b);
+uint8_t nk_topo_thread_shares_core_with_me (struct nk_thread * other);
+uint8_t nk_topo_threads_share_socket (struct nk_thread * a, struct nk_thread * b);
+uint8_t nk_topo_thread_shares_socket_with_me (struct nk_thread * other);
+
+void nk_topo_map_sibling_threads(void (func)(struct nk_thread *t, void *state), nk_topo_filt_t filter, void *state);
+void nk_topo_map_hwthread_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state);
+void nk_topo_map_core_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state);
+void nk_topo_map_socket_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state);
+/******* End Convenience API for thread topology ************/
+
+#endif 

--- a/include/nautilus/topo.h
+++ b/include/nautilus/topo.h
@@ -24,10 +24,10 @@
 #define __TOPO_H__
 
 typedef enum {
-	NK_ALL_FILT,       // all sibling threads/cpus 
-    NK_HW_THREAD_FILT, // thread on same hw thread (hyperthread)
-    NK_PHYS_CORE_FILT, // threads/CPUs on same physical core
-    NK_SOCKET_FILT,    // threads/CPUs on same socket
+	NK_TOPO_ALL_FILT,       // all sibling threads/cpus 
+    NK_TOPO_HW_THREAD_FILT, // thread on same hw thread (hyperthread)
+    NK_TOPO_PHYS_CORE_FILT, // threads/CPUs on same physical core
+    NK_TOPO_SOCKET_FILT,    // threads/CPUs on same socket
 } nk_topo_filt_t;
 
 /******* Convenience API for CPU topology ************/

--- a/src/nautilus/cpu.c
+++ b/src/nautilus/cpu.c
@@ -129,8 +129,8 @@ nk_topo_same_socket_as_me (struct cpu * other)
 
 static uint8_t (*const cpu_filter_funcs[])(struct cpu*, struct cpu*) = 
 {
-    [NK_PHYS_CORE_FILT] = nk_topo_cpus_share_phys_core,
-    [NK_SOCKET_FILT]    = nk_topo_cpus_share_socket,
+    [NK_TOPO_PHYS_CORE_FILT] = nk_topo_cpus_share_phys_core,
+    [NK_TOPO_SOCKET_FILT]    = nk_topo_cpus_share_socket,
 };
 
 
@@ -141,7 +141,7 @@ nk_topo_map_sibling_cpus (void (func)(struct cpu * cpu, void * state), nk_topo_f
     struct sys_info * sys = per_cpu_get(system);
     int i;
 
-    if (filter != NK_PHYS_CORE_FILT && filter != NK_SOCKET_FILT && filter != NK_ALL_FILT) {
+    if (filter != NK_TOPO_PHYS_CORE_FILT && filter != NK_TOPO_SOCKET_FILT && filter != NK_TOPO_ALL_FILT) {
         ERROR_PRINT("Sibling CPU mapping only supports socket-level and physcore-level mapping\n");
         return;
     }
@@ -150,7 +150,7 @@ nk_topo_map_sibling_cpus (void (func)(struct cpu * cpu, void * state), nk_topo_f
 		if (i == my_cpu_id())
 			continue;
 
-        if (filter == NK_ALL_FILT || cpu_filter_funcs[filter](get_cpu(), sys->cpus[i])) 
+        if (filter == NK_TOPO_ALL_FILT || cpu_filter_funcs[filter](get_cpu(), sys->cpus[i])) 
             func(sys->cpus[i], state);
     }
 }
@@ -158,13 +158,13 @@ nk_topo_map_sibling_cpus (void (func)(struct cpu * cpu, void * state), nk_topo_f
 void 
 nk_topo_map_core_sibling_cpus (void (func)(struct cpu * cpu, void * state), void * state)
 {
-    nk_topo_map_sibling_cpus(func, NK_PHYS_CORE_FILT, state);
+    nk_topo_map_sibling_cpus(func, NK_TOPO_PHYS_CORE_FILT, state);
 }
 
 void 
 nk_topo_map_socket_sibling_cpus (void (func)(struct cpu * cpu, void * state), void * state)
 {
-    nk_topo_map_sibling_cpus(func, NK_SOCKET_FILT, state);
+    nk_topo_map_sibling_cpus(func, NK_TOPO_SOCKET_FILT, state);
 }
 
 static void
@@ -183,7 +183,7 @@ handle_cputopotest (char * buf, void * priv)
         switch (aps) { 
             case 'a': 
 				nk_vc_printf("Mapping func to all siblings\n");
-                nk_topo_map_sibling_cpus(topo_test, NK_ALL_FILT, NULL);
+                nk_topo_map_sibling_cpus(topo_test, NK_TOPO_ALL_FILT, NULL);
                 break;
             case 'p': 
 				nk_vc_printf("Mapping func to core siblings\n");

--- a/src/nautilus/cpu.c
+++ b/src/nautilus/cpu.c
@@ -10,12 +10,12 @@
  * http://www.v3vee.org  and
  * http://xstack.sandia.gov/hobbes
  *
- * Copyright (c) 2015, Kyle C. Hale <kh@u.northwestern.edu>
+ * Copyright (c) 2015, Kyle C. Hale <khale@cs.iit.edu>
  * Copyright (c) 2015, The V3VEE Project  <http://www.v3vee.org> 
  *                     The Hobbes Project <http://xstack.sandia.gov/hobbes>
  * All rights reserved.
  *
- * Author: Kyle C. Hale <kh@u.northwestern.edu>
+ * Author: Kyle C. Hale <khale@cs.iit.edu>
  *
  * This is free software.  You are permitted to use,
  * redistribute, and modify it as specified in the file "LICENSE.txt".
@@ -60,6 +60,154 @@ nk_is_intel (void)
     get_vendor_string(name);
     return !strncmp(name, "GenuineIntel", 13);
 }
+
+
+uint32_t
+nk_get_smt_id (struct cpu * cpu)
+{
+    return cpu->coord->smt_id;
+}
+
+
+uint32_t
+nk_get_my_smt_id (void)
+{
+    return nk_get_smt_id(get_cpu());
+}
+
+
+uint32_t
+nk_get_socket_id (struct cpu * cpu)
+{
+    return cpu->coord->pkg_id;
+}
+
+
+uint32_t
+nk_get_my_socket_id (void)
+{
+    return nk_get_socket_id(get_cpu());
+}
+
+uint32_t
+nk_get_phys_core_id (struct cpu * cpu)
+{
+    return cpu->coord->core_id;
+}
+
+uint32_t
+nk_get_my_phys_core_id (void)
+{
+    return nk_get_phys_core_id(get_cpu());
+}
+
+uint8_t
+nk_cpus_share_phys_core (struct cpu * a, struct cpu * b)
+{
+    return nk_cpus_share_socket(a, b) && (a->coord->core_id == b->coord->core_id);
+}
+
+uint8_t
+nk_same_phys_core_as_me (struct cpu * other)
+{
+    return nk_cpus_share_phys_core(get_cpu(), other);
+}
+
+
+uint8_t
+nk_cpus_share_socket (struct cpu * a, struct cpu * b)
+{
+    return a->coord->pkg_id == b->coord->pkg_id;
+}
+
+uint8_t
+nk_same_socket_as_me (struct cpu * other)
+{
+    return nk_cpus_share_socket(get_cpu(), other);
+}
+
+static uint8_t (*const cpu_filter_funcs[])(struct cpu*, struct cpu*) = 
+{
+    [NK_PHYS_CORE_FILT] = nk_cpus_share_phys_core,
+    [NK_SOCKET_FILT]    = nk_cpus_share_socket,
+};
+
+
+// We assume CPUs are not changing at this point, so no locks necessary
+void
+nk_map_sibling_cpus (void (func)(struct cpu * cpu, void * state), nk_topo_filt_t filter, void * state)
+{
+    struct sys_info * sys = per_cpu_get(system);
+    int i;
+
+    if (filter != NK_PHYS_CORE_FILT && filter != NK_SOCKET_FILT && filter != NK_ALL_FILT) {
+        ERROR_PRINT("Sibling CPU mapping only supports socket-level and physcore-level mapping\n");
+        return;
+    }
+
+    for (i = 0; i < nk_get_num_cpus(); i++) {
+		if (i == my_cpu_id())
+			continue;
+
+        if (filter == NK_ALL_FILT || cpu_filter_funcs[filter](get_cpu(), sys->cpus[i])) 
+            func(sys->cpus[i], state);
+    }
+}
+
+void 
+nk_map_core_sibling_cpus (void (func)(struct cpu * cpu, void * state), void * state)
+{
+    nk_map_sibling_cpus(func, NK_PHYS_CORE_FILT, state);
+}
+
+void 
+nk_map_socket_sibling_cpus (void (func)(struct cpu * cpu, void * state), void * state)
+{
+    nk_map_sibling_cpus(func, NK_SOCKET_FILT, state);
+}
+
+static void
+topo_test (struct cpu * cpu, void * state)
+{
+    nk_vc_printf("MAPPER: Applying func to CPU %d\n", cpu->id);
+}
+
+static int
+handle_cputopotest (char * buf, void * priv)
+{
+    char aps;
+    if (((aps='a', strcmp(buf,"cputopotest a"))==0) ||
+			((aps='p', strcmp(buf,"cputopotest p"))==0) ||
+			((aps='s', strcmp(buf,"cputopotest s"))==0)) {
+        switch (aps) { 
+            case 'a': 
+				nk_vc_printf("Mapping func to all siblings\n");
+                nk_map_sibling_cpus(topo_test, NK_ALL_FILT, NULL);
+                break;
+            case 'p': 
+				nk_vc_printf("Mapping func to core siblings\n");
+                nk_map_core_sibling_cpus(topo_test, NULL);
+                break;
+            case 's': 
+				nk_vc_printf("Mapping func to socket siblings\n");
+                nk_map_socket_sibling_cpus(topo_test, NULL);
+                break;
+            default:
+                nk_vc_printf("Unknown cputopotest command requested\n");
+                return -1;
+        }
+    }
+
+    return 0;
+}
+
+static struct shell_cmd_impl cputopo_impl = {
+    .cmd      = "cputopotest",
+    .help_str = "cputopotest <a|p|s>",
+    .handler  = handle_cputopotest,
+};
+nk_register_shell_cmd(cputopo_impl);
+
 
 /*
  * nk_detect_cpu_freq
@@ -204,3 +352,6 @@ static struct shell_cmd_impl out_impl = {
     .handler  = handle_out,
 };
 nk_register_shell_cmd(out_impl);
+
+
+

--- a/src/nautilus/scheduler.c
+++ b/src/nautilus/scheduler.c
@@ -764,6 +764,142 @@ void nk_sched_map_threads(int cpu, void (func)(struct nk_thread *t, void *state)
     GLOBAL_UNLOCK();
 }
 
+/* KCH NOTE: The following helper functions *currently* assume that they will
+ * be called only from the map_sibling* functions below, thus locking is left out.
+ * DO NOT use them individually, otherwise you'll see race conditions.
+ */
+uint8_t nk_threads_share_hwthread (struct nk_thread * a, struct nk_thread * b)
+{
+    uint8_t res;
+    res = a->current_cpu == b->current_cpu;
+    return res;
+}
+
+uint8_t nk_thread_shares_hwthread_with_me (struct nk_thread * other)
+{
+    return nk_threads_share_hwthread(get_cur_thread(), other);
+}
+
+uint8_t nk_threads_share_core (struct nk_thread * a, struct nk_thread * b)
+{
+    uint8_t res;
+    struct sys_info *sys = per_cpu_get(system);
+    res = nk_cpus_share_phys_core(sys->cpus[a->current_cpu], sys->cpus[b->current_cpu]);
+    return res;
+}
+
+uint8_t nk_thread_shares_core_with_me (struct nk_thread * other)
+{
+    return nk_threads_share_core(get_cur_thread(), other);
+}
+
+uint8_t 
+nk_threads_share_socket (struct nk_thread * a, struct nk_thread * b)
+{
+    uint8_t res;
+    struct sys_info *sys = per_cpu_get(system);
+    res = nk_cpus_share_socket(sys->cpus[a->current_cpu], sys->cpus[b->current_cpu]);
+    return res;
+}
+
+uint8_t 
+nk_thread_shares_socket_with_me (struct nk_thread * other)
+{
+    return nk_threads_share_socket(get_cur_thread(), other);
+}
+
+
+static uint8_t (*const thread_filter_funcs[])(struct nk_thread*, struct nk_thread*) =
+{ 
+    [NK_HW_THREAD_FILT] = nk_threads_share_hwthread,
+    [NK_PHYS_CORE_FILT] = nk_threads_share_core,
+    [NK_SOCKET_FILT]    = nk_threads_share_socket,
+};
+
+// Map a function to all other threads on the same X, where X can be hwthread, physical core, or socket
+void nk_sched_map_sibling_threads(void (func)(struct nk_thread *t, void *state), nk_topo_filt_t filter, void *state)
+{
+    GLOBAL_LOCK_CONF;
+    GLOBAL_LOCK();
+
+    rt_node *n = global_sched_state.thread_list->head;
+
+    while (n != NULL) {
+        if (n->thread->thread != get_cur_thread()) { // skip myself
+            if (filter == NK_ALL_FILT ||
+                    thread_filter_funcs[filter](get_cur_thread(), n->thread->thread)) {
+                func(n->thread->thread, state);
+            }
+        }
+
+        n = n->next;
+    }
+
+    GLOBAL_UNLOCK();
+}
+
+void nk_sched_map_hwthread_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state)
+{
+    nk_sched_map_sibling_threads(func, NK_HW_THREAD_FILT, state);
+}
+
+void nk_sched_map_core_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state)
+{
+    nk_sched_map_sibling_threads(func, NK_PHYS_CORE_FILT, state);
+}
+
+void nk_sched_map_socket_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state)
+{
+    nk_sched_map_sibling_threads(func, NK_SOCKET_FILT, state);
+}
+
+static void
+topo_test (struct nk_thread * t, void * state)
+{
+    nk_vc_printf("THREADMAPPER: Applying func to thread %x\n", t->tid);
+}
+
+static int
+handle_threadtopotest (char * buf, void * priv)
+{
+    char aps;
+    if (((aps='a', strcmp(buf,"threadtopotest a"))==0) ||
+			((aps='l', strcmp(buf,"threadtopotest l"))==0) ||
+			((aps='p', strcmp(buf,"threadtopotest p"))==0) ||
+			((aps='s', strcmp(buf,"threadtopotest s"))==0)) {
+        switch (aps) { 
+            case 'a': 
+				nk_vc_printf("Mapping func to all siblings\n");
+                nk_sched_map_sibling_threads(topo_test,  NK_ALL_FILT, NULL);
+                break;
+            case 'l': 
+				nk_vc_printf("Mapping func to logical core siblings\n");
+                nk_sched_map_hwthread_sibling_threads(topo_test,  NULL);
+                break;
+            case 'p': 
+				nk_vc_printf("Mapping func to core siblings\n");
+                nk_sched_map_core_sibling_threads(topo_test, NULL);
+                break;
+            case 's': 
+				nk_vc_printf("Mapping func to socket siblings\n");
+                nk_sched_map_socket_sibling_threads(topo_test, NULL);
+                break;
+            default:
+                nk_vc_printf("Unknown threadtopotest command requested\n");
+                return -1;
+        }
+    }
+
+    return 0;
+}
+
+static struct shell_cmd_impl threadtopo_impl = {
+    .cmd      = "threadtopotest",
+    .help_str = "threadtopotest <a|s|p|l>",
+    .handler  = handle_threadtopotest,
+};
+nk_register_shell_cmd(threadtopo_impl);
+
 
 void nk_sched_stop_world()
 {

--- a/src/nautilus/scheduler.c
+++ b/src/nautilus/scheduler.c
@@ -812,9 +812,9 @@ nk_topo_thread_shares_socket_with_me (struct nk_thread * other)
 
 static uint8_t (*const thread_filter_funcs[])(struct nk_thread*, struct nk_thread*) =
 { 
-    [NK_HW_THREAD_FILT] = nk_topo_threads_share_hwthread,
-    [NK_PHYS_CORE_FILT] = nk_topo_threads_share_core,
-    [NK_SOCKET_FILT]    = nk_topo_threads_share_socket,
+    [NK_TOPO_HW_THREAD_FILT] = nk_topo_threads_share_hwthread,
+    [NK_TOPO_PHYS_CORE_FILT] = nk_topo_threads_share_core,
+    [NK_TOPO_SOCKET_FILT]    = nk_topo_threads_share_socket,
 };
 
 // Map a function to all other threads on the same X, where X can be hwthread, physical core, or socket
@@ -827,7 +827,7 @@ void nk_topo_map_sibling_threads(void (func)(struct nk_thread *t, void *state), 
 
     while (n != NULL) {
         if (n->thread->thread != get_cur_thread()) { // skip myself
-            if (filter == NK_ALL_FILT ||
+            if (filter == NK_TOPO_ALL_FILT ||
                     thread_filter_funcs[filter](get_cur_thread(), n->thread->thread)) {
                 func(n->thread->thread, state);
             }
@@ -841,17 +841,17 @@ void nk_topo_map_sibling_threads(void (func)(struct nk_thread *t, void *state), 
 
 void nk_topo_map_hwthread_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state)
 {
-    nk_topo_map_sibling_threads(func, NK_HW_THREAD_FILT, state);
+    nk_topo_map_sibling_threads(func, NK_TOPO_HW_THREAD_FILT, state);
 }
 
 void nk_topo_map_core_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state)
 {
-    nk_topo_map_sibling_threads(func, NK_PHYS_CORE_FILT, state);
+    nk_topo_map_sibling_threads(func, NK_TOPO_PHYS_CORE_FILT, state);
 }
 
 void nk_topo_map_socket_sibling_threads(void (func)(struct nk_thread *t, void *state), void *state)
 {
-    nk_topo_map_sibling_threads(func, NK_SOCKET_FILT, state);
+    nk_topo_map_sibling_threads(func, NK_TOPO_SOCKET_FILT, state);
 }
 
 static void
@@ -871,7 +871,7 @@ handle_threadtopotest (char * buf, void * priv)
         switch (aps) { 
             case 'a': 
 				nk_vc_printf("Mapping func to all siblings\n");
-                nk_topo_map_sibling_threads(topo_test,  NK_ALL_FILT, NULL);
+                nk_topo_map_sibling_threads(topo_test,  NK_TOPO_ALL_FILT, NULL);
                 break;
             case 'l': 
 				nk_vc_printf("Mapping func to logical core siblings\n");


### PR DESCRIPTION
This pull request has two components:

- 81caa93 fixes topology enumeration on both Intel and AMD (tested on QEMU), so that we can now actually get hwthread, physical core, and socket IDs for a Nautilus CPU. AMD is still not fully functional, but it should work on <= latest Opteron systems.
- 32eb02e adds a convenience API on top of this information. One can now easily get hwthread/core/socket ID of a given CPU or thread, and map functions to siblings within those units. Two tests within the shell now demonstrate this, cputopotest and threadtopotest. 

The newer EPYC systems are going to require some rethought of this due to their divergence from Intel on package organization.