### PR TITLE
Update shell.c

### DIFF
--- a/src/nautilus/shell.c
+++ b/src/nautilus/shell.c
@@ -717,7 +717,7 @@ shell (void * in, void ** out)
 
     if (op->script) {
         int i;
-        for (i = 0; *op->script[i]; i++) {
+        for (i = 0; op->script[i]; i++) {
             nk_vc_printf("***exec: %s\n", op->script[i]);
             shell_handle_cmd(state, op->script[i], SHELL_MAX_CMD);
         }


### PR DESCRIPTION
Fix pointer mistake in shell startup-operation handling.

* **Please check if the request fulfills these requirements**
- [X] The commit messages follow our guidelines (See [Contributing](https://github.com/HExSA-Lab/nautilus/blob/master/CONTRIBUTING.md)).
- [X] The code follows our style guidelines, again see Contributing.
- [N/A] If this is a new feature, changes to the core kernel have been minimized.
- [N/A] If this feature doesn't touch the core kernel, has it been properly separated out in the `Kconfig`? and the source tree?
- [N/A] If this pull request is for an open issue, the issue is properly referenced.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Reads invalid operations from memory until it finds the value zero. 

* **What is the new behavior (if this is a feature change)?**

Reads valid operations from memory until it finds a pointer of zero.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

I sure hope not.

* **Other information**:

Stumbled across this while testing some stuff for CS343 at Northwestern. Figured it would be good to upstream it.
