### PR TITLE
AMD topology/PMC fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+FROM ubuntu:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y \
+    bat \
+    binutils \
+    clang \
+    cscope \
+    ctags \
+    curl \
+    emacs \
+    fd-find \
+    fish \
+    fzf \
+    gcc \
+    gdb \
+    git \
+    grub2 \ 
+    htop \
+    language-pack-en \
+    llvm \
+    locate \
+    make \
+    ncurses-dev \
+    neovim \
+    netcat \
+    perl \
+    python3 \
+    python3-pip \
+    qemu-system-x86 \
+    silversearcher-ag \
+    software-properties-common \
+    ssh \
+    tig \
+    tmux \
+    valgrind \
+    xorriso \ 
+    xxd 
+
+# for powerline
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN add-apt-repository -y ppa:lazygit-team/release && \
+    apt-get update && \
+    apt-get install -y fonts-powerline lazygit
+
+RUN pip3 install -U pandas numpy seaborn scipy matplotlib docopt
+
+# install nvim plugins before I get in
+RUN sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim' && \
+    git clone https://github.com/khale/neovim-config && \
+    mkdir -p /root/.config/nvim && \
+    mv neovim-config/init.vim /root/.config/nvim/ && \
+    rm -rf neovim-config && \
+    nvim --headless +PlugInstall +qall
+
+RUN git clone https://github.com/khale/dotfiles && \
+    mkdir -p /root/.config/fish && \
+    mv dotfiles/fish-config /root/.config/fish/config.fish && \
+    mv dotfiles/gitnow-config ~/.gitflow && \
+    git clone https://github.com/khale/fisher-config && \
+    mv fisher-config/fishfile /root/.config/fish/ && \
+    rm -rf fisher-config && \
+    git clone https://github.com/khale/.tmux && \
+    cp .tmux/.tmux.conf /root && \
+    cp .tmux/.tmux.conf.local /root
+
+WORKDIR /hack
+
+CMD ["/usr/bin/fish"]
+

--- a/include/nautilus/cpuid.h
+++ b/include/nautilus/cpuid.h
@@ -27,6 +27,7 @@
 #include <nautilus/naut_types.h>
 
 uint32_t cpuid_leaf_max(void);
+uint32_t cpuid_ext_leaf_max(void);
 uint8_t cpuid_get_family(void);
 uint8_t cpuid_get_model(void);
 uint8_t cpuid_get_step(void);

--- a/include/nautilus/numa.h
+++ b/include/nautilus/numa.h
@@ -96,6 +96,7 @@ struct nk_topo_params {
     // amd
     uint32_t max_ncores;
     uint32_t max_nthreads;
+    uint8_t has_topoext;
 
     // intel
 	uint32_t core_plus_mask_width;

--- a/src/nautilus/cpuid.c
+++ b/src/nautilus/cpuid.c
@@ -75,6 +75,14 @@ cpuid_get_step (void)
 }
 
 
+uint32_t 
+cpuid_ext_leaf_max (void)
+{
+    cpuid_ret_t ret;
+    cpuid(0x80000000, &ret);
+    return ret.a & 0xff;
+}
+
 uint32_t
 cpuid_leaf_max (void)
 {


### PR DESCRIPTION
This PR adds two things for AMD:
* Better PMC support
* Ability to enumerate CPU topology without crashing on Zen chips (EPYC, Ryzen, etc)

