### PR TITLE
    Add panic decoder script

### DIFF
--- a/tools/decode_panic.pl
+++ b/tools/decode_panic.pl
@@ -1,0 +1,53 @@
+#!/usr/bin/perl -w
+#
+
+$do_edit = $#ARGV>=0 ;
+
+# name of the file that includes the panic
+$serial = "./serial.out";
+# the kernel binary
+$kernel = "./nautilus.bin";
+# where to find the source tree
+$tree =   "./";
+# the prefix from the decoded file locations to remove
+$cut =    "/home/pdinda/test/nautilus/";
+# the editor you want to use to traverse the panic
+$editor = "vim";
+# how to tell that editor to start at a particular line
+$lineno_prefix = "+";
+
+(-e $kernel) or die "no kernel file $kernel\n";
+(-e $serial) or die "no serial file $serial\n";
+
+open(S,$serial) or die "cannot open serial file $serial\n";
+
+while (<S>) {
+    if (/\[.+\]\s+RIP:\s+(\S+)/ || /RIP:\s+\S+\:(\S+)/) {                                                           
+	$seq .= $1." ";
+	push @rips, $1;
+    }
+}
+
+defined($seq) or die "No panic detected in $serial\n";                                                            
+
+close(S);
+
+@locs = `addr2line -e $kernel $seq`;
+
+chomp(@locs);
+
+# print the raw decoded stack trace trace
+print map { "$rips[$_]\t$locs[$_]\n" } 0..$#locs;
+
+
+if ($do_edit) {
+    # walk the raw decoded stack trace back
+    # file by file
+    foreach $l (@locs) {
+	($file,$line) = split(/\:/,$l);
+	$file =~ s/^$cut//g;
+	$cmd = "$editor $tree$file $lineno_prefix$line";                                                        
+	#       print $cmd,"\n";
+	system $cmd;
+    }
+}


### PR DESCRIPTION
    To use:

    1. edit tools/decode_panic.pl for your setup
    2. after a panic, run tools/decode_panic.pl to get a human readable
       stack trace
    3. you can also run "tools/decode_panic.pl edit" to walk back the
       stack function by function

* **Please check if the request fulfills these requirements**
- [X ] The commit messages follow our guidelines (See [Contributing](https://github.com/HExSA-Lab/nautilus/blob/master/CONTRIBUTING.md)).
- [ X] The code follows our style guidelines, again see Contributing.
- [ X] If this is a new feature, changes to the core kernel have been minimized.
- [ X] If this feature doesn't touch the core kernel, has it been properly separated out in the `Kconfig`? and the source tree?
- [ X] If this pull request is for an open issue, the issue is properly referenced.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Decoder script for a panic so that we don't have to do objdump by hand

* **What is the current behavior?** (You can also link to an open issue here)

We have to decode a stack trace on a panic by hand



* **What is the new behavior (if this is a feature change)?**

We now don't have to


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Nope - just decodes serial output

* **Other information**:
